### PR TITLE
[FIX] sale_coupon_auto_refresh: fix MissingError error

### DIFF
--- a/sale_coupon_auto_refresh/__init__.py
+++ b/sale_coupon_auto_refresh/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import wizard

--- a/sale_coupon_auto_refresh/wizard/__init__.py
+++ b/sale_coupon_auto_refresh/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_coupon_apply_code

--- a/sale_coupon_auto_refresh/wizard/sale_coupon_apply_code.py
+++ b/sale_coupon_auto_refresh/wizard/sale_coupon_apply_code.py
@@ -1,0 +1,9 @@
+from odoo import models
+
+
+class SaleCouponApplyCode(models.TransientModel):
+    _inherit = "sale.coupon.apply.code"
+
+    def process_coupon(self):
+        wiz = self.with_context(skip_auto_refresh_coupons=True)
+        return super(SaleCouponApplyCode, wiz).process_coupon()


### PR DESCRIPTION
When applying a promo code via wizard, Odoo creates a sale.order.line *before* filling the sale.order `code_promo_program_id` field.
After the creation, though, the auto refresh override kicks in, calling the `recompute_coupon_lines` method.
That method finds a sale.order.line that was created from a promo program, but such program is not linked to the sale.order, and so the line gets deleted.
However, since the line has just been created, Odoo will try to run the `_check_company` method on it, which will try to read the field `company_id` of the deleted line.
This operation will result in a `MissingError`, raised by the `__get__` method of `Field` class.

This error is fixed by adding the `skip_auto_refresh_coupons` flag to the wizard context when executing the `process_coupon` method.