### PR TITLE
[IMP] sale_coupon_order_line_link: link sale lines to rewards

### DIFF
--- a/sale_coupon_order_line_link/README.rst
+++ b/sale_coupon_order_line_link/README.rst
@@ -29,10 +29,24 @@ This module adds a link in the sale order line to the program used in a discount
 it can be easily tracked afterwards. Also eases the implementation of coupon modules
 that don't necessarily use the discount product as product for the discount line.
 
+It also links the reward lines to:
+  - The order lines that generated them, so we can follow which order lines produced
+    which discounts.
+  - The order lines over which the reward is applied:
+    
+    - In a discount promo: the cheapest product, specific products or the whole order.
+    - In a product promo: the product lines over which the reward is discounted.
+
 **Table of contents**
 
 .. contents::
    :local:
+
+Known issues / Roadmap
+======================
+
+* Rename to `sale_coupon_traceability` in v14 as it fits better the broad features
+  of the module.
 
 Bug Tracker
 ===========

--- a/sale_coupon_order_line_link/models/sale_order.py
+++ b/sale_coupon_order_line_link/models/sale_order.py
@@ -1,6 +1,7 @@
 # Copyright 2021 Tecnativa - David Vidal
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import fields, models
+from odoo.tools.safe_eval import safe_eval
 
 
 class SaleOrder(models.Model):
@@ -13,13 +14,105 @@ class SaleOrder(models.Model):
         return res
 
     def _get_reward_values_discount(self, program):
-        """Add the link to the program in the discount line"""
-        res = super()._get_reward_values_discount(program)
-        # The original method returns a dict.values(), which is weird:
-        # https://git.io/J88As
-        vals = [r for r in res][0]
-        vals["coupon_program_id"] = program.id
-        return {"x": vals}.values()
+        """Add the link to the program in the discount line. The original method returns
+        a dict.values() to support multiple taxes. We can safely return a list instead
+        as the main method just iterates over the result of these auxiliar products to
+        write vals. https://git.io/J88As
+        """
+        res = list(super()._get_reward_values_discount(program))
+        [r.update(coupon_program_id=program.id) for r in res]
+        return res
+
+    def write(self, vals):
+        """We're looking for reward lines set in the write, from those, we'll get
+        the proper ids to write them into the related lines"""
+        res = super().write(vals)
+        reward_lines = [
+            x[2]
+            for x in vals.get("order_line", [])
+            if len(x) > 2 and x[0] == 0 and x[2].get("is_reward_line")
+        ]
+        if not reward_lines:
+            return res
+        programs = self.env["sale.coupon.program"].browse(
+            list({x.get("coupon_program_id") for x in reward_lines})
+        )
+        for order in self:
+            order._link_reward_lines(programs)
+            order._link_reward_generated_lines(programs)
+        return res
+
+    def _link_reward_discount_lines(self, program):
+        """Assign reward lines depending on the discount scope of the promotion:
+        - A discount on order, will apply to every line.
+        - A discount on the cheapest product just to the cheapest line.
+        - A discount on specific products only on those products defined in the
+          promotion and available in the order lines.
+        Thes filters are the same the core methods use.
+        """
+        reward_lines = self.order_line.filtered(
+            lambda x: x.coupon_program_id == program
+        )
+        # TODO: Should we add the lines that meet the criteria even if they aren't
+        # on the filtered lines?
+        if program.discount_apply_on == "on_order":
+            lines = self.order_line.filtered(lambda x: not x.is_reward_line)
+        elif program.discount_apply_on == "cheapest_product":
+            lines = self._get_cheapest_line()
+        elif program.discount_apply_on == "specific_products":
+            lines = self.order_line.filtered(
+                lambda x: x.product_id in program.discount_specific_product_ids
+            )
+        # Distribute different tax reward lines with their correspondant order lines.
+        # We use a dictionary so we can compare taxes even if they are composed.
+        tax_reward_map = {}
+        for reward_line in reward_lines:
+            tax_reward_map.setdefault(reward_line.tax_id, self.env["sale.order.line"])
+            tax_reward_map[reward_line.tax_id] |= reward_line
+        for tax, tax_reward_lines in tax_reward_map.items():
+            lines.filtered(lambda x: x.tax_id == tax).write(
+                {"reward_line_ids": [(4, rl.id) for rl in tax_reward_lines]}
+            )
+
+    def _link_reward_product_lines(self, program):
+        """We want to link to the reward those lines that generated it as well as
+        the rewarded product, that could be not in the original domain"""
+        reward_lines = self.order_line.filtered(
+            lambda x: x.coupon_program_id == program
+        )
+        lines_with_reward_product_id = self.order_line.filtered(
+            lambda x: x.product_id == program.reward_product_id
+        )
+        # We'll just consider as many lines as the reward quantity can cover.
+        lines = self.env["sale.order.line"]
+        reward_qty = program.reward_product_quantity
+        for line in lines_with_reward_product_id:
+            lines |= line
+            if line.product_uom_qty >= reward_qty:
+                break
+            reward_qty -= line.product_uom_qty
+        lines.write({"reward_line_ids": [(4, rl.id) for rl in reward_lines]})
+
+    def _link_reward_lines(self, programs):
+        """We want to filter the lines that generated a condition and link them to
+        the generated rewards. Every reward type has it's own cases depending on
+        how's applied. Another reward types (e.g: sale_coupon_delivey) should extend
+        this method adding its cases. Also to be noted that a single line could
+        generate several rewards coming from different promotions."""
+        for program in programs.filtered(lambda x: x.reward_type == "discount"):
+            self._link_reward_discount_lines(program)
+        for program in programs.filtered(lambda x: x.reward_type == "product"):
+            self._link_reward_product_lines(program)
+
+    def _link_reward_generated_lines(self, programs):
+        """Link the lines that generated reward lines to those lines"""
+        for program in programs:
+            reward_lines = self.order_line.filtered(
+                lambda x: x.coupon_program_id == program
+            )
+            self.order_line._filter_related_program_lines(program).write(
+                {"reward_generated_line_ids": [(4, rl.id) for rl in reward_lines]}
+            )
 
 
 class SaleOrderLine(models.Model):
@@ -30,3 +123,43 @@ class SaleOrderLine(models.Model):
         ondelete="restrict",
         string="Coupon Program",
     )
+    reward_line_ids = fields.Many2many(
+        comodel_name="sale.order.line",
+        relation="sale_line_reward_line_rel",
+        column1="sale_line_id",
+        column2="reward_line_id",
+        string="Reward lines",
+        help="Link on the reward lines applied from this one",
+    )
+    reward_generated_line_ids = fields.Many2many(
+        comodel_name="sale.order.line",
+        relation="sale_line_reward_generated_line_rel",
+        column1="sale_line_id",
+        column2="reward_generated_line_id",
+        string="Reward Generated lines",
+        help="Link on the reward lines generated meeting this line as criteria",
+    )
+
+    def write(self, vals):
+        """When the reward line is update we should refresh the line links as well"""
+        res = super().write(vals)
+        if vals.get("is_reward_line") and vals.get("coupon_program_id"):
+            program = self.env["sale.coupon.program"].browse(
+                vals.get("coupon_program_id")
+            )
+            for order in self.mapped("order_id"):
+                order._link_reward_lines(program)
+        return res
+
+    def _filter_related_program_lines(self, program):
+        """Discard those lines not in the program domain. With other modules changing
+        the product criteria rules, we can extend this method to return the proper
+        records."""
+        # No domain means that any product meets the promotion rules
+        if not program.rule_products_domain:
+            return self
+        domain = safe_eval(program.rule_products_domain)
+        products = self.mapped("product_id").filtered_domain(domain)
+        return self.filtered(
+            lambda x: x.product_id in products and not x.is_reward_line
+        )

--- a/sale_coupon_order_line_link/readme/DESCRIPTION.rst
+++ b/sale_coupon_order_line_link/readme/DESCRIPTION.rst
@@ -1,3 +1,11 @@
 This module adds a link in the sale order line to the program used in a discount, so
 it can be easily tracked afterwards. Also eases the implementation of coupon modules
 that don't necessarily use the discount product as product for the discount line.
+
+It also links the reward lines to:
+  - The order lines that generated them, so we can follow which order lines produced
+    which discounts.
+  - The order lines over which the reward is applied:
+
+    - In a discount promo: the cheapest product, specific products or the whole order.
+    - In a product promo: the product lines over which the reward is discounted.

--- a/sale_coupon_order_line_link/readme/ROADMAP.rst
+++ b/sale_coupon_order_line_link/readme/ROADMAP.rst
@@ -1,0 +1,2 @@
+* Rename to `sale_coupon_traceability` in v14 as it fits better the broad features
+  of the module.

--- a/sale_coupon_order_line_link/static/description/index.html
+++ b/sale_coupon_order_line_link/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Link coupons to order lines</title>
 <style type="text/css">
 
@@ -371,20 +371,41 @@ ul.auto-toc {
 <p>This module adds a link in the sale order line to the program used in a discount, so
 it can be easily tracked afterwards. Also eases the implementation of coupon modules
 that don’t necessarily use the discount product as product for the discount line.</p>
+<dl class="docutils">
+<dt>It also links the reward lines to:</dt>
+<dd><ul class="first last simple">
+<li>The order lines that generated them, so we can follow which order lines produced
+which discounts.</li>
+<li>The order lines over which the reward is applied:<ul>
+<li>In a discount promo: the cheapest product, specific products or the whole order.</li>
+<li>In a product promo: the product lines over which the reward is discounted.</li>
+</ul>
+</li>
+</ul>
+</dd>
+</dl>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#bug-tracker" id="id1">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id2">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id3">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id4">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id5">Maintainers</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="id1">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id2">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id3">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id4">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id5">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id6">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="known-issues-roadmap">
+<h1><a class="toc-backref" href="#id1">Known issues / Roadmap</a></h1>
+<ul class="simple">
+<li>Rename to <cite>sale_coupon_traceability</cite> in v14 as it fits better the broad features
+of the module.</li>
+</ul>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id1">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id2">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/sale-promotion/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -392,15 +413,15 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id2">Credits</a></h1>
+<h1><a class="toc-backref" href="#id3">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id3">Authors</a></h2>
+<h2><a class="toc-backref" href="#id4">Authors</a></h2>
 <ul class="simple">
 <li>Tecnativa</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id4">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id5">Contributors</a></h2>
 <ul class="simple">
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>David Vidal</li>
@@ -409,7 +430,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id5">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose

--- a/sale_coupon_order_line_link/tests/test_coupon_order_line_link.py
+++ b/sale_coupon_order_line_link/tests/test_coupon_order_line_link.py
@@ -28,19 +28,29 @@ class TestSaleCouponCriteriaMultiProduct(common.SavepointCase):
             {"name": "Mr. Odoo", "property_product_pricelist": cls.pricelist.id}
         )
         cls.product_a = product_obj.create({"name": "Product A", "list_price": 50})
+        cls.product_b = product_obj.create({"name": "Product B", "list_price": 10})
+        cls.product_c = product_obj.create({"name": "Product C", "list_price": 70})
+        cls.tax_1 = cls.env["account.tax"].create(
+            {"name": "Tax 10", "type_tax_use": "sale", "amount": 10}
+        )
+        cls.tax_2 = cls.env["account.tax"].create(
+            {"name": "Tax 4", "type_tax_use": "sale", "amount": 4}
+        )
         coupon_program_form = Form(
             cls.env["sale.coupon.program"],
             view="sale_coupon.sale_coupon_program_view_promo_program_form",
         )
-        coupon_program_form.name = "Test Program"
+        coupon_program_form.name = "Test Coupon Line Link Program"
         coupon_program_form.promo_code_usage = "no_code_needed"
         coupon_program_form.reward_type = "discount"
-        coupon_program_form.discount_apply_on = "on_order"
+        coupon_program_form.discount_apply_on = "specific_products"
         coupon_program_form.discount_type = "percentage"
         coupon_program_form.discount_percentage = 10
-        coupon_program_form.rule_products_domain = "[('id', '=', %s)]" % (
-            cls.product_a.id
-        )
+        coupon_program_form.rule_products_domain = [
+            ("id", "in", (cls.product_a | cls.product_b | cls.product_c).ids)
+        ]
+        coupon_program_form.discount_specific_product_ids.add(cls.product_a)
+        coupon_program_form.discount_specific_product_ids.add(cls.product_c)
         cls.coupon_program = coupon_program_form.save()
         # We'll be using this sale order
         sale_form = Form(cls.env["sale.order"])
@@ -48,10 +58,114 @@ class TestSaleCouponCriteriaMultiProduct(common.SavepointCase):
         with sale_form.order_line.new() as line_form:
             line_form.product_id = cls.product_a
             line_form.product_uom_qty = 1
+            line_form.tax_id.clear()
+            line_form.tax_id.add(cls.tax_1)
+        with sale_form.order_line.new() as line_form:
+            line_form.product_id = cls.product_b
+            line_form.product_uom_qty = 1
+            line_form.tax_id.clear()
+            line_form.tax_id.add(cls.tax_1)
+        with sale_form.order_line.new() as line_form:
+            line_form.product_id = cls.product_c
+            line_form.product_uom_qty = 1
+            line_form.tax_id.clear()
+            line_form.tax_id.add(cls.tax_2)
         cls.sale = sale_form.save()
 
-    def test_coupon_order_line_link(self):
-        """The coupon program gets correctly linked to the line"""
+    def test_01_coupon_order_line_link_discount(self):
+        """The reward lines always get the coupon program that applied it. For the order
+        lines, three main cases are covered:
+        - Discount on specific products. Only those lines get link to the reward lines.
+        - Global discount. All the order lines get the link to the reward lines.
+        """
         self.sale.recompute_coupon_lines()
-        discount_line = self.sale.order_line.filtered("is_reward_line")
-        self.assertEqual(discount_line.coupon_program_id, self.coupon_program)
+        lines = self.sale.order_line
+        discount_line_1 = lines.filtered(
+            lambda x: x.is_reward_line and x.tax_id == self.tax_1
+        )
+        discount_line_2 = lines.filtered(
+            lambda x: x.is_reward_line and x.tax_id == self.tax_2
+        )
+        line_a = lines.filtered(lambda x: x.product_id == self.product_a)
+        line_b = lines.filtered(lambda x: x.product_id == self.product_b)
+        line_c = lines.filtered(lambda x: x.product_id == self.product_c)
+        # Two discount are created from the program
+        self.assertEqual(discount_line_1.coupon_program_id, self.coupon_program)
+        self.assertEqual(discount_line_2.coupon_program_id, self.coupon_program)
+        # Only the program specific products get the link to the reward lines
+        self.assertEqual(line_a.reward_line_ids, discount_line_1)
+        self.assertFalse(line_b.reward_line_ids)
+        self.assertEqual(line_c.reward_line_ids, discount_line_2)
+        # All the lines apply on the domain
+        self.assertEqual(
+            line_a.reward_generated_line_ids, discount_line_1 | discount_line_2
+        )
+        self.assertEqual(
+            line_b.reward_generated_line_ids, discount_line_1 | discount_line_2
+        )
+        self.assertEqual(
+            line_c.reward_generated_line_ids, discount_line_1 | discount_line_2
+        )
+        # Change the program discount type to a global discount. Now all the lines
+        # have a link to the coupon reward lines
+        self.coupon_program.discount_apply_on = "on_order"
+        self.sale.recompute_coupon_lines()
+        self.assertEqual(line_a.reward_line_ids, discount_line_1)
+        self.assertEqual(line_b.reward_line_ids, discount_line_1)
+        self.assertEqual(line_c.reward_line_ids, discount_line_2)
+
+    def test_02_coupon_order_line_link_discount_cheapest(self):
+        """Change the program discount type to a cheapest product. Now only the chepest
+        line will get the reward."""
+        self.coupon_program.discount_apply_on = "cheapest_product"
+        self.sale.recompute_coupon_lines()
+        lines = self.sale.order_line
+        discount_line_1 = lines.filtered(
+            lambda x: x.is_reward_line and x.tax_id == self.tax_1
+        )
+        discount_line_2 = lines.filtered(
+            lambda x: x.is_reward_line and x.tax_id == self.tax_2
+        )
+        line_a = lines.filtered(lambda x: x.product_id == self.product_a)
+        line_b = lines.filtered(lambda x: x.product_id == self.product_b)
+        line_c = lines.filtered(lambda x: x.product_id == self.product_c)
+        self.assertEqual(discount_line_1.coupon_program_id, self.coupon_program)
+        self.assertEqual(line_b.reward_line_ids, discount_line_1)
+        self.assertFalse(line_a.reward_line_ids)
+        self.assertFalse(line_c.reward_line_ids)
+        discount_line_2 = self.sale.order_line.filtered(
+            lambda x: x.is_reward_line and x.tax_id == self.tax_2
+        )
+        self.assertFalse(discount_line_2, "There shouldn't be a reward for tax 2")
+
+    def test_03_coupon_order_line_link_product(self):
+        """The reward lines are linked to the coupon programs and the lines that
+        genereate the reward line are linked to that
+        """
+        # Let's set up the program for product rewards
+        self.coupon_program.reward_type = "product"
+        self.coupon_program.reward_product_id = self.product_c
+        self.coupon_program.reward_product_quantity = 5
+        self.coupon_program.rule_products_domain = [("id", "=", self.product_a.id)]
+        sale_form = Form(self.sale)
+        with sale_form.order_line.new() as line_form:
+            line_form.product_id = self.product_c
+            line_form.product_uom_qty = 6
+            line_form.tax_id.clear()
+            line_form.tax_id.add(self.tax_2)
+        sale_form.save()
+        # Refresh the order coupons
+        self.sale.recompute_coupon_lines()
+        lines = self.sale.order_line
+        reward_line = self.sale.order_line.filtered(lambda x: x.is_reward_line)
+        line_a = lines.filtered(lambda x: x.product_id == self.product_a)
+        line_b = lines.filtered(lambda x: x.product_id == self.product_b)
+        lines_c = lines.filtered(lambda x: x.product_id == self.product_c)
+        self.assertEqual(reward_line.coupon_program_id, self.coupon_program)
+        self.assertFalse(line_a.reward_line_ids)
+        self.assertFalse(line_b.reward_line_ids)
+        for line in lines_c:
+            self.assertEqual(line.reward_line_ids, reward_line)
+            self.assertFalse(line.reward_generated_line_ids)
+        self.assertEqual(line_a.reward_generated_line_ids, reward_line)
+        self.assertFalse(line_b.reward_generated_line_ids)


### PR DESCRIPTION
Filter lines that are related to a reward: either they genereted it or the reward is applied to them. For example:

- A promotion product domain could be: `("id", "=" product_a.id)`
- The same promotion has a reward product B
- On a sale order with products A, B and C:
  - A reward line will be generated to discount B's amount and will be linked to the promotion.
  - Line A will have a link to the reward line as it was the condition for the promotion.
  - Line B will also have a link to the reward line as it's the line over which the discount is made.

cc @Tecnativa TT31755

please review @carlosdauden @sergio-teruel @pedrobaeza 