### PR TITLE
[IMP] sale_coupon_limit: usage info

### DIFF
--- a/sale_coupon_limit/models/sale_coupon.py
+++ b/sale_coupon_limit/models/sale_coupon.py
@@ -41,18 +41,16 @@ class SaleCoupon(models.Model):
         salesman_rule = self.program_id.rule_salesmen_limit_ids.filtered(
             lambda x: order.user_id == x.rule_user_id
         )
-        if salesman_rule:
-            coupons_count = self.search_count(
-                domain + [("sales_order_id.user_id", "=", order.user_id.id)]
-            )
-            if coupons_count >= salesman_rule.rule_max_salesman_application:
-                return {
-                    "error": _(
-                        "This promotion was already applied %s times for this "
-                        "salesman and there's an stablished limit of %s."
-                    )
-                    % (coupons_count, salesman_rule.rule_max_salesman_application)
-                }
+        max_rule = salesman_rule.rule_max_salesman_application
+        times_used = salesman_rule.rule_times_used
+        if times_used and times_used >= max_rule:
+            return {
+                "error": _(
+                    "This promotion was already applied %s times for this "
+                    "salesman and there's an stablished limit of %s."
+                )
+                % (times_used, max_rule)
+            }
         if self.program_id.rule_salesmen_strict_limit and not salesman_rule:
             return {"error": _("This promotion is restricted to the listed salesmen.")}
         return message

--- a/sale_coupon_limit/models/sale_coupon_program.py
+++ b/sale_coupon_limit/models/sale_coupon_program.py
@@ -45,27 +45,17 @@ class SaleCouponProgram(models.Model):
         salesman_rule = self.rule_salesmen_limit_ids.filtered(
             lambda x: order.user_id == x.rule_user_id
         )
-        if salesman_rule:
-            salesman_domain = domain + [("user_id", "=", order.user_id.id)]
-            order_count = self.env["sale.order"].search_count(salesman_domain)
-            limit_reached = order_count >= salesman_rule.rule_max_salesman_application
-            if limit_reached and coupon_code:
-                return {
-                    "error": _(
-                        "This promo code was already applied %s times for this "
-                        "salesman and there's an stablished limit of %s for this "
-                        "promotion."
-                    )
-                    % (order_count, salesman_rule.rule_max_salesman_application)
-                }
-            elif limit_reached and not coupon_code:
-                return {
-                    "error": _(
-                        "This promotion was already applied %s times for this "
-                        "salesman and there's an stablished limit of %s."
-                    )
-                    % (order_count, salesman_rule.rule_max_salesman_application)
-                }
+        max_rule = salesman_rule.rule_max_salesman_application
+        times_used = salesman_rule.rule_times_used
+        if times_used and times_used >= max_rule:
+            return {
+                "error": _(
+                    "This promo code was already applied %s times for this "
+                    "salesman and there's an stablished limit of %s for this "
+                    "promotion."
+                )
+                % (times_used, max_rule)
+            }
         if self.rule_salesmen_strict_limit and not salesman_rule:
             return {"error": _("This promotion is restricted to the listed salesmen.")}
         return message

--- a/sale_coupon_limit/models/sale_coupon_rule.py
+++ b/sale_coupon_limit/models/sale_coupon_rule.py
@@ -28,14 +28,24 @@ class SaleCouponRule(models.Model):
         string="Salesmen maximum promotions",
         compute="_compute_rule_salesmen_limit_count",
     )
+    rule_salesmen_limit_used_count = fields.Integer(
+        string="Salesmen promotions used", compute="_compute_rule_salesmen_limit_count",
+    )
 
-    @api.depends("rule_salesmen_limit_ids.rule_max_salesman_application")
+    @api.depends(
+        "rule_salesmen_limit_ids.rule_max_salesman_application",
+        "rule_salesmen_limit_ids.rule_times_used",
+    )
     def _compute_rule_salesmen_limit_count(self):
+        """This count is merely informative"""
+        self.rule_salesmen_limit_count = 0
+        self.rule_salesmen_limit_used_count = 0
         for rule in self:
             rule.rule_salesmen_limit_count = sum(
-                rule.rule_salesmen_limit_ids.mapped(
-                    "rule_salesmen_limit_ids.rule_max_salesman_application"
-                )
+                rule.rule_salesmen_limit_ids.mapped("rule_max_salesman_application")
+            )
+            rule.rule_salesmen_limit_used_count = sum(
+                rule.rule_salesmen_limit_ids.mapped("rule_times_used")
             )
 
 
@@ -57,6 +67,7 @@ class SaleCouponRuleSalesmenLimit(models.Model):
         default=0,
         help="Maximum times a salesman can apply a program. 0 for no limit.",
     )
+    rule_times_used = fields.Integer(string="Uses", compute="_compute_rule_times_used",)
 
     _sql_constraints = [
         (
@@ -65,3 +76,50 @@ class SaleCouponRuleSalesmenLimit(models.Model):
             "This salesman limit is already configured",
         ),
     ]
+
+    @api.depends("rule_user_id", "rule_max_salesman_application")
+    def _compute_rule_times_used(self):
+        """This count is also used in the check methods to avoid applying the rule
+        above the salesmen limits."""
+        self.rule_times_used = 0
+        programs = self.env["sale.coupon.program"].search_read(
+            [("rule_id", "in", self.mapped("rule_id").ids)],
+            ["id", "rule_id", "program_type", "coupon_ids", "rule_salesmen_limit_ids"],
+        )
+        coupon_programs = [
+            p
+            for p in programs
+            if p["program_type"]
+            and p["program_type"] == "coupon_program"
+            or p["coupon_ids"]
+        ]
+        for program in programs:
+            salesmen_limits = self.filtered(
+                lambda x: x._origin.id in program["rule_salesmen_limit_ids"]
+            )
+            for salesman_limit in salesmen_limits:
+                if program in coupon_programs and not program["coupon_ids"]:
+                    continue
+                elif program in coupon_programs:
+                    salesman_limit.rule_times_used = self.env[
+                        "sale.coupon"
+                    ].search_count(
+                        [
+                            ("program_id", "=", program["id"]),
+                            ("state", "=", "used"),
+                            (
+                                "sales_order_id.user_id",
+                                "=",
+                                salesman_limit.rule_user_id.id,
+                            ),
+                        ]
+                    )
+                    continue
+                salesman_limit.rule_times_used = self.env["sale.order"].search_count(
+                    [
+                        "|",
+                        ("no_code_promo_program_ids", "in", [program["id"]]),
+                        ("code_promo_program_id", "=", [program["id"]]),
+                        ("user_id", "=", salesman_limit.rule_user_id.id),
+                    ]
+                )

--- a/sale_coupon_limit/tests/test_sale_coupon_limit.py
+++ b/sale_coupon_limit/tests/test_sale_coupon_limit.py
@@ -272,6 +272,7 @@ class TestSaleCouponLimit(common.SavepointCase):
         sale_5 = self._create_sale(self.partner_1, self.salesman_2)
         self._apply_coupon(sale_5, last_coupon.code)
         self.assertTrue(bool(sale_5.order_line.filtered("is_reward_line")))
+        self.coupon_program.rule_salesmen_limit_ids.mapped("rule_times_used")
 
     def test_08_coupon_code_next_order_salesmen_limit(self):
         """Coupons should not be generated for next orders above the salesman limit"""

--- a/sale_coupon_limit/views/sale_coupon_program_views.xml
+++ b/sale_coupon_limit/views/sale_coupon_program_views.xml
@@ -8,6 +8,7 @@
         <field name="model">sale.coupon.program</field>
         <field name="arch" type="xml">
             <field name="rule_products_domain" position="after">
+                <!-- rule_max_customer_application -->
                 <label
                     string="Max. Customer Applications"
                     for="rule_max_customer_application"
@@ -15,11 +16,28 @@
                 <div>
                     <field name="rule_max_customer_application" class="oe_inline" />
                 </div>
+                <!-- rule_salesmen_limit_count -->
+                <label
+                    string="Max. Salesmen Applications"
+                    for="rule_salesmen_limit_count"
+                />
+                <div>
+                    <field name="rule_salesmen_limit_count" class="oe_inline" />
+                    <span class="oe_grey"> (<field
+                            name="rule_salesmen_limit_used_count"
+                            class="oe_inline"
+                        /> used already)</span>
+                </div>
                 <field name="rule_salesmen_strict_limit" />
                 <field name="rule_salesmen_limit_ids">
                     <tree editable="bottom">
-                        <field name="rule_max_salesman_application" string="Max" />
+                        <field
+                            sum="Total limit"
+                            name="rule_max_salesman_application"
+                            string="Max"
+                        />
                         <field name="rule_user_id" />
+                        <field sum="Total used" name="rule_times_used" />
                     </tree>
                 </field>
             </field>


### PR DESCRIPTION
We add some compute fields to check the current promotion usage by the
limited users. That allows us to refactor the check method a little bit
as well unifying the logic.

cc @Tecnativa TT30847

please review @pedrobaeza 