### PR TITLE
[FIX] sale_coupon_auto_refresh: crash when removing promotion line

### DIFF
--- a/sale_coupon_auto_refresh/models/sale_order.py
+++ b/sale_coupon_auto_refresh/models/sale_order.py
@@ -49,19 +49,25 @@ class SaleOrderLine(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        lines = super().create(vals_list)
+        lines = super(
+            SaleOrderLine, self.with_context(skip_auto_refresh_coupons=True)
+        ).create(vals_list)
         lines.mapped("order_id")._auto_refresh_coupons()
         return lines
 
     def write(self, vals):
         orders = self.mapped("order_id")
-        res = super().write(vals)
+        res = super(
+            SaleOrderLine, self.with_context(skip_auto_refresh_coupons=True)
+        ).write(vals)
         orders |= self.mapped("order_id")
         orders._auto_refresh_coupons()
         return res
 
     def unlink(self):
         orders = self.mapped("order_id")
-        res = super().unlink()
+        res = super(
+            SaleOrderLine, self.with_context(skip_auto_refresh_coupons=True)
+        ).unlink()
         orders._auto_refresh_coupons()
         return res


### PR DESCRIPTION
we need to pass skip_auto_refresh_coupons=True in the context when
adding / editing / removing lines otherwise we can end up with the
promotion line being added twice or removed twice (the latter causing a
crash)