### PR TITLE
[14.0][FIX] sale_coupon_auto_refresh: fix MissingError for good

### DIFF
--- a/sale_coupon_auto_refresh/models/__init__.py
+++ b/sale_coupon_auto_refresh/models/__init__.py
@@ -1,3 +1,4 @@
 from . import res_config_settings
 from . import res_company
+from . import sale_coupon_refresh_mixin
 from . import sale_order

--- a/sale_coupon_auto_refresh/models/sale_coupon_refresh_mixin.py
+++ b/sale_coupon_auto_refresh/models/sale_coupon_refresh_mixin.py
@@ -1,0 +1,65 @@
+# Copyright 2021 Tecnativa - David Vidal
+# Copyright 2021 Camptocamp - Silvio Gregorini
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class SaleCouponRefreshMixin(models.AbstractModel):
+    _name = "sale.coupon.refresh.mixin"
+    _description = "Mixin class for sale coupon auto-refresh features"
+
+    auto_refresh_coupon_triggers_data = fields.Binary(
+        attachment=False,
+        compute="_compute_auto_refresh_coupon_triggers_data",
+        store=False,
+    )
+
+    @api.model
+    def _get_auto_refresh_coupons_triggers(self) -> set:
+        """Returns set of fields which trigger the recomputation
+
+        Hook method to be overridden if necessary
+        """
+        return set()
+
+    @api.depends(lambda self: list(self._get_auto_refresh_coupons_triggers()))
+    def _compute_auto_refresh_coupon_triggers_data(self):
+        triggers = self._get_auto_refresh_coupons_triggers()
+        for rec in self:
+            data = dict()
+            for dotted_field_name in triggers:
+                val = rec.mapped(dotted_field_name)
+                if isinstance(val, models.AbstractModel):
+                    val = val.ids
+                data[dotted_field_name] = val
+            rec.auto_refresh_coupon_triggers_data = data
+
+    def _read_recs_data(self) -> list:
+        """Reads `auto_refresh_coupon_triggers_data` for all records in `self`
+
+        :return: list of dicts:
+
+            [{"id": x, "auto_refresh_coupon_triggers_data": y}]
+
+            each dict representing a different record (as a result
+            of `self.read()`)
+            The list is sorted by "id" key.
+        """
+        return sorted(
+            self.read(["auto_refresh_coupon_triggers_data"]), key=lambda d: d["id"]
+        )
+
+    def _check_skip_refresh(self):
+        """Checks whether refresh should be skipped
+
+        Hook method to be overridden if necessary
+        :return: True if auto-refresh should be skipped
+        """
+        ctx = self.env.context
+        # Checking for `website_id` because `website_sale_coupon` already
+        # refreshes coupons on every cart_update and every checkout
+        # controller reload
+        # NB: no need to add `website_sale_coupon` as dependency since we
+        # only use it for this context flag
+        return ctx.get("skip_auto_refresh_coupons") or ctx.get("website_id")


### PR DESCRIPTION
This commit, alongside with odoo/odoo#78255, fixes MissingError being raised when:
- the line(s) that allow coupons to be applied are deleted
- the line(s) that allow coupons to be applied are updated making coupons applicable no more

Moreover:
- a check on which fields are updated is introduced in order to boost performances
- the module has been slightly refactored for better readability

Closes #20
