### PR TITLE
[FIX] sale_coupon_limit: compatibility with sale_couopon_selection_wizard

### DIFF
--- a/sale_coupon_limit/models/sale_coupon.py
+++ b/sale_coupon_limit/models/sale_coupon.py
@@ -12,8 +12,11 @@ class SaleCoupon(models.Model):
         message = super()._check_coupon_code(order)
         if message:
             return message
+        # The module sale_couopon_selection_wizard works with new records to probe
+        # if a promotion is applicable before apply it for sure. Thus we need to ensure
+        # the right id in the domain.
         domain = [
-            ("order_id", "!=", order.id),
+            ("order_id", "!=", order._origin.id),
             ("program_id", "=", self.program_id.id),
             ("state", "=", "used"),
         ]

--- a/sale_coupon_limit/models/sale_coupon_program.py
+++ b/sale_coupon_limit/models/sale_coupon_program.py
@@ -12,7 +12,10 @@ class SaleCouponProgram(models.Model):
         message = super()._check_promo_code(order, coupon_code)
         if message:
             return message
-        domain = [("id", "!=", order.id)] + (
+        # The module sale_couopon_selection_wizard works with new records to probe
+        # if a promotion is applicable before apply it for sure. Thus we need to ensure
+        # the right id in the domain.
+        domain = [("id", "!=", order._origin.id)] + (
             [("promo_code", "=", coupon_code)]
             if coupon_code
             else [("no_code_promo_program_ids", "in", self.ids)]


### PR DESCRIPTION
`sale_couopon_selection_wizard` works with new records to probe if a promotion is applicable before apply it for sure. Thus we need to ensure the right id in the domain.

cc @Tecnativa TT32558