### PR TITLE
[13.0][FIX] sale_coupon_limit: cancelled orders

### DIFF
--- a/sale_coupon_limit/models/sale_coupon_program.py
+++ b/sale_coupon_limit/models/sale_coupon_program.py
@@ -15,7 +15,7 @@ class SaleCouponProgram(models.Model):
         # The module sale_couopon_selection_wizard works with new records to probe
         # if a promotion is applicable before apply it for sure. Thus we need to ensure
         # the right id in the domain.
-        domain = [("id", "!=", order._origin.id)] + (
+        domain = [("id", "!=", order._origin.id), ("state", "!=", "cancel")] + (
             [("promo_code", "=", coupon_code)]
             if coupon_code
             else [("no_code_promo_program_ids", "in", self.ids)]


### PR DESCRIPTION
Coupons are reset when a sale order is cancelled, but applied programs
remain linked to the cancelled order. As they're cancelled, we should
not count them in the limits.

cc @Tecnativa TT34264

please review @CarlosRoca13 @pedrobaeza 