### PR TITLE
[ADD] sale_coupon_reward_add_product

### DIFF
--- a/sale_coupon_reward_add_product/__init__.py
+++ b/sale_coupon_reward_add_product/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/sale_coupon_reward_add_product/__manifest__.py
+++ b/sale_coupon_reward_add_product/__manifest__.py
@@ -1,0 +1,17 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Julien Coux <julien.coux@camptocamp.com>
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Sale Coupon Automatic free product as normal",
+    "summary": "Sale Coupon Automatic free product as normal",
+    "version": "14.0.1.0.0",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "maintainers": ["jcoux", "ivantodorovich"],
+    "website": "https://github.com/OCA/sale-promotion",
+    "license": "AGPL-3",
+    "category": "Website",
+    "depends": ["sale_coupon", "onchange_helper"],
+    "data": ["views/coupon_program.xml"],
+}

--- a/sale_coupon_reward_add_product/models/__init__.py
+++ b/sale_coupon_reward_add_product/models/__init__.py
@@ -1,0 +1,4 @@
+from . import coupon_coupon
+from . import coupon_program
+from . import coupon_reward
+from . import sale_order

--- a/sale_coupon_reward_add_product/models/coupon_coupon.py
+++ b/sale_coupon_reward_add_product/models/coupon_coupon.py
@@ -1,0 +1,15 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class CouponCoupon(models.Model):
+    _inherit = "coupon.coupon"
+
+    def _check_coupon_code(self, order):
+        # OVERRIDE to skip the _is_reward_in_order_lines check
+        if self.program_id.reward_product_add_if_missing:
+            order = order.with_context(check_reward_in_order_lines=False)
+        return super()._check_coupon_code(order)

--- a/sale_coupon_reward_add_product/models/coupon_program.py
+++ b/sale_coupon_reward_add_product/models/coupon_program.py
@@ -1,0 +1,66 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class CouponProgram(models.Model):
+    _inherit = "coupon.program"
+
+    def _check_promo_code(self, order, coupon_code):
+        # OVERRIDE to skip the _is_reward_in_order_lines check
+        if self.reward_product_add_if_missing:
+            order = order.with_context(check_reward_in_order_lines=False)
+        return super()._check_promo_code(order, coupon_code)
+
+    def _filter_programs_on_products(self, order):
+        # OVERRIDE
+        records = super()._filter_programs_on_products(order)
+        # Just like super, map ordered product quantities
+        order_lines = (
+            order.order_line.filtered("product_id") - order._get_reward_lines()
+        )
+        products = order_lines.product_id
+        products_qties = dict.fromkeys(products, 0)
+        for line in order_lines:
+            products_qties[line.product_id] += line.product_uom_qty
+        # Handle discarded programs by super()
+        for rec in self:
+            if (
+                rec.promo_applicability == "on_current_order"
+                and rec.promo_code_usage == "code_needed"
+                and rec.reward_type == "product"
+                and rec.reward_product_add_if_missing
+                and rec not in records
+            ):
+                # The original method will discard the program if the reward product
+                # is not included in the current order's products.
+                # But since we're adding it automatically, we need to account for the
+                # reward product that's going to be added too.
+                valid_products = rec._get_valid_products(products)
+                ordered_rule_products_qty = sum(
+                    products_qties[product] for product in valid_products
+                )
+                required_products_qty = (
+                    rec.rule_min_quantity - rec.reward_product_quantity
+                )
+                if ordered_rule_products_qty >= required_products_qty:
+                    records += rec
+        return records
+
+    def _filter_not_ordered_reward_programs(self, order):
+        # OVERRIDE to avoid filtering out programs where the reward is missing but
+        # it's going to be added automatically anyways.
+        records_to_keep = self.filtered(
+            lambda rec: (
+                rec.reward_type == "product"
+                and rec.promo_code_usage == "code_needed"
+                and rec.reward_product_add_if_missing
+            )
+        )
+        records_to_filter = self - records_to_keep
+        programs = super(
+            CouponProgram, records_to_filter
+        )._filter_not_ordered_reward_programs(order)
+        return programs | records_to_keep

--- a/sale_coupon_reward_add_product/models/coupon_reward.py
+++ b/sale_coupon_reward_add_product/models/coupon_reward.py
@@ -1,0 +1,14 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class CouponReward(models.Model):
+    _inherit = "coupon.reward"
+
+    reward_product_add_if_missing = fields.Boolean(
+        string="Add reward product to the order automatically",
+        help="If checked, the reward product will be automatically added to the order",
+    )

--- a/sale_coupon_reward_add_product/models/sale_order.py
+++ b/sale_coupon_reward_add_product/models/sale_order.py
@@ -1,0 +1,40 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    def _is_reward_in_order_lines(self, program):
+        if not self.env.context.get("check_reward_in_order_lines", True):
+            return True
+        return super()._is_reward_in_order_lines(program)
+
+    def _prepare_reward_product_line_vals(self, program):
+        return {
+            "order_id": self.id,
+            "product_id": program.reward_product_id.id,
+            "product_uom": program.reward_product_id.uom_id.id,
+        }
+
+    def _create_reward_line(self, program):
+        # OVERRIDE to add the reward product to the order automatically
+        if program.reward_product_add_if_missing:
+            reward_product_lines = self.order_line.filtered(
+                lambda line: line.product_id == program.reward_product_id
+            )
+            order_quantity = sum(reward_product_lines.mapped("product_uom_qty"))
+            if order_quantity < program.reward_product_quantity:
+                qty_to_add = float(program.reward_product_quantity) - order_quantity
+                line_vals = self._prepare_reward_product_line_vals(program)
+                line_vals.update(product_uom_qty=qty_to_add)
+                line_vals.update(
+                    self.env["sale.order.line"].play_onchanges(
+                        line_vals, line_vals.keys()
+                    )
+                )
+                self.env["sale.order.line"].create(line_vals)
+        return super()._create_reward_line(program)

--- a/sale_coupon_reward_add_product/readme/CONFIGURE.rst
+++ b/sale_coupon_reward_add_product/readme/CONFIGURE.rst
@@ -1,0 +1,1 @@
+On your program reward settings, enable **Add if missing**.

--- a/sale_coupon_reward_add_product/readme/CONTRIBUTORS.rst
+++ b/sale_coupon_reward_add_product/readme/CONTRIBUTORS.rst
@@ -1,0 +1,4 @@
+* `Camptocamp <https://www.camptocamp.com>`_
+
+    * Julien Coux <julien.coux@camptocamp.com>
+    * Iván Todorovich <ivan.todorovich@camptocamp.com>

--- a/sale_coupon_reward_add_product/readme/DESCRIPTION.rst
+++ b/sale_coupon_reward_add_product/readme/DESCRIPTION.rst
@@ -1,0 +1,5 @@
+When using promotions and coupons to reward a free product, the rewarded product
+needs to be added to the order before applying the coupon.
+
+This module allows you to configure promotions in such a way that the rewarded
+product is added automatically if it's missing.

--- a/sale_coupon_reward_add_product/tests/__init__.py
+++ b/sale_coupon_reward_add_product/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sale

--- a/sale_coupon_reward_add_product/tests/test_sale.py
+++ b/sale_coupon_reward_add_product/tests/test_sale.py
@@ -1,0 +1,66 @@
+# Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+# @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import SavepointCase
+
+
+class TestCouponAddProduct(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        cls.partner = cls.env.ref("base.res_partner_1")
+        cls.product = cls.env["product.product"].create({"name": "Test"})
+        cls.program = cls.env["coupon.program"].create(
+            {
+                "name": "Test Free Product Auto",
+                "promo_code_usage": "code_needed",
+                "promo_code": "TEST_FREE_PRODUCT_AUTO",
+                "reward_type": "product",
+                "reward_product_id": cls.product.id,
+                "reward_product_add_if_missing": True,
+            }
+        )
+        cls.order = cls.env["sale.order"].create({"partner_id": cls.partner.id})
+
+    def _apply_coupon(self, order, coupon_code):
+        return self.env["sale.coupon.apply.code"].apply_coupon(order, coupon_code)
+
+    def _generate_coupon(self, program):
+        CouponGenerateWizard = self.env["coupon.generate.wizard"]
+        wizard = CouponGenerateWizard.with_context(active_id=program.id).create({})
+        wizard.generate_coupon()
+        return program.coupon_ids[-1]
+
+    def test_program_code_auto(self):
+        res = self._apply_coupon(self.order, self.program.promo_code)
+        self.assertFalse(res)
+        self.assertEqual(len(self.order.order_line), 2)
+        self.assertIn(self.program.reward_product_id, self.order.order_line.product_id)
+
+    def test_coupon_code_auto(self):
+        coupon = self._generate_coupon(self.program)
+        res = self._apply_coupon(self.order, coupon.code)
+        self.assertFalse(res)
+        self.assertEqual(len(self.order.order_line), 2)
+        self.assertIn(self.program.reward_product_id, self.order.order_line.product_id)
+
+    def test_program_code_disabled(self):
+        self.program.reward_product_add_if_missing = False
+        res = self._apply_coupon(self.order, self.program.promo_code)
+        self.assertEqual(
+            res["error"],
+            "The reward products should be in the sales order lines to apply the discount.",
+        )
+        self.assertFalse(self.order.order_line)
+
+    def test_coupon_code_disabled(self):
+        self.program.reward_product_add_if_missing = False
+        coupon = self._generate_coupon(self.program)
+        res = self._apply_coupon(self.order, coupon.code)
+        self.assertEqual(
+            res["error"],
+            "The reward products should be in the sales order lines to apply the discount.",
+        )
+        self.assertFalse(self.order.order_line)

--- a/sale_coupon_reward_add_product/views/coupon_program.xml
+++ b/sale_coupon_reward_add_product/views/coupon_program.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+    Copyright 2022 Camptocamp SA (https://www.camptocamp.com).
+    @author Iván Todorovich <ivan.todorovich@camptocamp.com>
+    License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+-->
+<odoo>
+
+    <record id="coupon_program_view_promo_program_form" model="ir.ui.view">
+        <field name="model">coupon.program</field>
+        <field name="inherit_id" ref="coupon.coupon_program_view_promo_program_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='reward_product_uom_id']/parent::div"
+                position="after"
+            >
+                <field
+                    name="reward_product_add_if_missing"
+                    string="Add if missing"
+                    attrs="{
+                        'invisible': [
+                            '|',
+                            ('reward_type', '!=', 'product'),
+                            ('promo_code_usage', '!=', 'code_needed'),
+                        ]
+                    }"
+                />
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/setup/sale_coupon_reward_add_product/odoo/addons/sale_coupon_reward_add_product
+++ b/setup/sale_coupon_reward_add_product/odoo/addons/sale_coupon_reward_add_product
@@ -1,0 +1,1 @@
+../../../../sale_coupon_reward_add_product

--- a/setup/sale_coupon_reward_add_product/setup.py
+++ b/setup/sale_coupon_reward_add_product/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
When using promotions and coupons to reward a free product, the rewarded product needs to be added to the order before applying the coupon.

This module allows you to configure promotions in such a way that the rewarded product is added automatically if it's missing.