### PR TITLE
[13.0][FIX] sale_coupon_multi_gift: mixed rewards

### DIFF
--- a/sale_coupon_multi_gift/__manifest__.py
+++ b/sale_coupon_multi_gift/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Coupons multi gift",
     "summary": "Allows to configure multiple gift rewards per promotion",
-    "version": "13.0.2.0.0",
+    "version": "13.0.3.0.0",
     "development_status": "Beta",
     "category": "Sale",
     "website": "https://github.com/OCA/sale-promotion",

--- a/sale_coupon_multi_gift/migrations/13.0.3.0.0/post-migrate.py
+++ b/sale_coupon_multi_gift/migrations/13.0.3.0.0/post-migrate.py
@@ -1,0 +1,28 @@
+# Copyright 2022 Tecnativa - David Vidal
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """Link lines and reward lines"""
+    multi_gift_programs = env["sale.coupon.program"].search(
+        [("reward_type", "=", "multi_gift")]
+    )
+    for program in multi_gift_programs:
+        order_lines = env["sale.order.line"].search(
+            [("is_reward_line", "=", "True"), ("coupon_program_id", "=", program.id)]
+        )
+        for reward_line in program.coupon_multi_gift_ids:
+            reward_lines = order_lines.filtered(
+                lambda x: x.product_id in reward_line.reward_product_ids
+            )
+            # Remember the choice
+            for product in reward_lines.product_id:
+                reward_lines.write(
+                    {
+                        "multi_gift_reward_line_id": reward_line.id,
+                        "multi_gift_reward_line_id_option_product_id": product.id,
+                    }
+                )
+            order_lines -= reward_lines

--- a/sale_coupon_multi_gift/models/sale_order.py
+++ b/sale_coupon_multi_gift/models/sale_order.py
@@ -1,6 +1,6 @@
 # Copyright 2021 Tecnativa - David Vidal
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import _, models
+from odoo import _, fields, models
 from odoo.fields import first
 
 
@@ -55,6 +55,8 @@ class SaleOrder(models.Model):
                 "name": _("Free Product") + " - " + reward_product_id.name,
                 "discount": 100,
                 "coupon_program_id": program.id,
+                "multi_gift_reward_line_id": reward_line.id,
+                "multi_gift_reward_line_id_option_product_id": reward_product_id.id,
             }
         )
         return vals
@@ -140,21 +142,33 @@ class SaleOrder(models.Model):
             lambda x: x.reward_type == "multi_gift"
         ):
             for reward_line in program.coupon_multi_gift_ids:
-                values = self._get_reward_values_multi_gift_line(reward_line, program)
                 lines = self.order_line.filtered(
-                    lambda line: line.product_id in reward_line.reward_product_ids
+                    lambda line: line.multi_gift_reward_line_id == reward_line
                     and line.is_reward_line
                     and line.coupon_program_id == program
                 )
-                # Remove reward line if price or qty equal to 0
-                if values.get("product_uom_qty") and values.get("price_unit"):
-                    lines.write(values)
-                else:
-                    lines.unlink()
+                applied_product = lines.multi_gift_reward_line_id_option_product_id
+                for product in applied_product:
+                    reward_line_options = {reward_line.id: product.id}
+                    values = self.with_context(
+                        reward_line_options=reward_line_options
+                    )._get_reward_values_multi_gift_line(reward_line, program)
+                    # Remove reward line if price or qty equal to 0
+                    if values.get("product_uom_qty") and values.get("price_unit"):
+                        lines.write(values)
+                    else:
+                        lines.unlink()
 
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
+
+    multi_gift_reward_line_id = fields.Many2one(
+        comodel_name="sale.coupon.reward.product_line", readonly=True,
+    )
+    multi_gift_reward_line_id_option_product_id = fields.Many2one(
+        comodel_name="product.product", readonly=True,
+    )
 
     def unlink(self):
         """Avoid unlinking valid multi gift lines since they aren't linked to the


### PR DESCRIPTION
When we've got mixed optional rewards we need to tell for sure which reward line belongs a sale line to so we can apply the right product when the reward is updated.

cc @Tecnativa TT34266

- [x] TODO: add test

please review @pedrobaeza @CarlosRoca13 