### PR TITLE
[FIX] sale_coupon_limit: improve rule times used count

### DIFF
--- a/sale_coupon_limit/__manifest__.py
+++ b/sale_coupon_limit/__manifest__.py
@@ -10,6 +10,10 @@
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "maintainers": ["chienandalu"],
     "license": "AGPL-3",
-    "depends": ["sale_coupon", "sale_commercial_partner"],
+    "depends": [
+        "sale_coupon",
+        "sale_commercial_partner",
+        "sale_coupon_order_line_link",
+    ],
     "data": ["views/sale_coupon_program_views.xml", "security/ir.model.access.csv"],
 }


### PR DESCRIPTION
Sometimes Odoo doesn't remove the rules properly until the promotions
are refreshed. This could lead to count mismatches. We wan't to ensure
the count looking at the lines instead.

cc @Tecnativa TT34266

ping @pedrobaeza 