### PR TITLE
[13.0][FIX] sale_coupon_multiplier_free_product: performance on large orders

### DIFF
--- a/sale_coupon_multiplier_free_product/tests/test_website_sale_coupon_free_product.py
+++ b/sale_coupon_multiplier_free_product/tests/test_website_sale_coupon_free_product.py
@@ -7,6 +7,7 @@ class TestSaleCouponMultiplier(common.SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
         cls.pricelist = cls.env["product.pricelist"].create(
             {
                 "name": "Test pricelist",


### PR DESCRIPTION
Dismiss `test.Form()` to compute the price_unit for the discounted
reward, as its suboptimal the larger the sale is. It should be enough a
simple onchange trigger, which is similar to the way the ecommerce does
it on the `_website_product_id_change` method.

A showcase of the performance in a real world database with a sale with ~70 lines in the ecommerce after adding a single unit to the cart:
![image](https://user-images.githubusercontent.com/5040182/171029563-e7794775-a939-4dbf-a3a4-0cc00be3ed99.png)


cc @Tecnativa TT36761

please review @pedrobaeza @carlosdauden 