### PR TITLE
[13.0][IMP] sale_coupon_auto_refresh: configurable triggers

### DIFF
--- a/sale_coupon_auto_refresh/README.rst
+++ b/sale_coupon_auto_refresh/README.rst
@@ -40,6 +40,21 @@ You can set this feature on or off in every company. To do so:
 #. Go to *Sales > Configuration > Settings*
 #. In the *Pricing* section you'll find the option *Auto refresh promotions*.
 
+The auto-refresh in the backend is triggered over a minimum set of fields changes. If
+you want to extend the list of that fields:
+
+#. Go to *Settings > Technical > Config parameters*
+#. Add or update the key:
+
+   - For `sale.order`: `sale_coupon_auto_refresh.sale_order_triggers`
+   - For `sale.order.line`: `sale_coupon_auto_refresh.sale_order_line_triggers`
+#. In every add the fields seperated by commas that you want to add to the recomputation
+   triggers.
+
+⚠️ After configuring or removiming a trigger a restart of Odoo is recommended so the
+depends are reloaded properly. Anyway it isn't mandatory and the module detects the
+new triggers so the auto-refresh works as expected as soon as they are set.
+
 Usage
 =====
 

--- a/sale_coupon_auto_refresh/models/sale_order.py
+++ b/sale_coupon_auto_refresh/models/sale_order.py
@@ -30,7 +30,10 @@ class SaleOrder(models.Model):
         self_ctx = self.with_context(skip_auto_refresh_coupons=True)
         res = super(SaleOrder, self_ctx).write(vals)
         new_data = self._read_recs_data()
-        if old_data != new_data:
+        # Until we restart Odoo, we won't get new triggers from params. Once restarted
+        # the method will return an empty set.
+        new_triggers = self._new_trigger()
+        if old_data != new_data or any(x in new_triggers for x in vals):
             self._auto_refresh_coupons()
         return res
 
@@ -83,7 +86,10 @@ class SaleOrderLine(models.Model):
         res = super(SaleOrderLine, self_ctx).write(vals)
         new_data = self._read_recs_data()
         new_orders = self.mapped("order_id")
-        if old_data != new_data:
+        # Until we restart Odoo, we won't get new triggers from params. Once restarted
+        # the method will return an empty set.
+        new_triggers = self._new_trigger()
+        if old_data != new_data or any(x in new_triggers for x in vals):
             (old_orders | new_orders)._auto_refresh_coupons()
         return res
 

--- a/sale_coupon_auto_refresh/readme/CONFIGURE.rst
+++ b/sale_coupon_auto_refresh/readme/CONFIGURE.rst
@@ -2,3 +2,18 @@ You can set this feature on or off in every company. To do so:
 
 #. Go to *Sales > Configuration > Settings*
 #. In the *Pricing* section you'll find the option *Auto refresh promotions*.
+
+The auto-refresh in the backend is triggered over a minimum set of fields changes. If
+you want to extend the list of that fields:
+
+#. Go to *Settings > Technical > Config parameters*
+#. Add or update the key:
+
+   - For `sale.order`: `sale_coupon_auto_refresh.sale_order_triggers`
+   - For `sale.order.line`: `sale_coupon_auto_refresh.sale_order_line_triggers`
+#. In every add the fields seperated by commas that you want to add to the recomputation
+   triggers.
+
+⚠️ After configuring or removiming a trigger a restart of Odoo is recommended so the
+depends are reloaded properly. Anyway it isn't mandatory and the module detects the
+new triggers so the auto-refresh works as expected as soon as they are set.

--- a/sale_coupon_auto_refresh/static/description/index.html
+++ b/sale_coupon_auto_refresh/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Auto Refresh Coupons</title>
 <style type="text/css">
 
@@ -391,6 +391,21 @@ ul.auto-toc {
 <li>Go to <em>Sales &gt; Configuration &gt; Settings</em></li>
 <li>In the <em>Pricing</em> section you’ll find the option <em>Auto refresh promotions</em>.</li>
 </ol>
+<p>The auto-refresh in the backend is triggered over a minimum set of fields changes. If
+you want to extend the list of that fields:</p>
+<ol class="arabic simple">
+<li>Go to <em>Settings &gt; Technical &gt; Config parameters</em></li>
+<li>Add or update the key:<ul>
+<li>For <cite>sale.order</cite>: <cite>sale_coupon_auto_refresh.sale_order_triggers</cite></li>
+<li>For <cite>sale.order.line</cite>: <cite>sale_coupon_auto_refresh.sale_order_line_triggers</cite></li>
+</ul>
+</li>
+<li>In every add the fields seperated by commas that you want to add to the recomputation
+triggers.</li>
+</ol>
+<p>⚠️ After configuring or removiming a trigger a restart of Odoo is recommended so the
+depends are reloaded properly. Anyway it isn’t mandatory and the module detects the
+new triggers so the auto-refresh works as expected as soon as they are set.</p>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#id2">Usage</a></h1>

--- a/sale_coupon_auto_refresh/tests/test_sale_coupon_auto_refresh.py
+++ b/sale_coupon_auto_refresh/tests/test_sale_coupon_auto_refresh.py
@@ -7,6 +7,7 @@ class TestWebsiteSaleCouponAutorefresh(common.SavepointCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
         cls.pricelist = cls.env["product.pricelist"].create(
             {
                 "name": "Test pricelist",
@@ -39,6 +40,10 @@ class TestWebsiteSaleCouponAutorefresh(common.SavepointCase):
         coupon_program_form.rule_minimum_amount = 100
         cls.coupon_program = coupon_program_form.save()
         cls.coupon_program.company_id.auto_refresh_coupon = True
+        # Let's configure an extra trigger
+        cls.env["ir.config_parameter"].set_param(
+            "sale_coupon_auto_refresh.sale_order_triggers", "note"
+        )
 
     def test_01_sale_coupon_auto_refresh_on_create(self):
         """Checks reward line proper creation after product line is added"""
@@ -128,3 +133,24 @@ class TestWebsiteSaleCouponAutorefresh(common.SavepointCase):
         sale = sale_form.save()
         discount_line = sale.order_line.filtered("is_reward_line")
         self.assertFalse(bool(discount_line))
+
+    def test_04_sale_coupon_auto_refresh_custom_triggers(self):
+        """Checks reward line proper update after product line is modified"""
+        self.env.company.auto_refresh_coupon = False
+        sale_form = Form(self.env["sale.order"])
+        sale_form.partner_id = self.partner
+        # Create a product line that would trigger the reward but we disabled it by
+        # context
+        with sale_form.order_line.new() as line_form:
+            line_form.product_id = self.product
+            line_form.product_uom_qty = 10
+            line_form.price_unit = 20
+        sale = sale_form.save()
+        discount_line = sale.order_line.filtered("is_reward_line")
+        self.assertFalse(bool(discount_line))
+        self.env.company.auto_refresh_coupon = True
+        sale.with_context(skip_auto_refresh_coupons=False).note = "Refresh!"
+        # The promotions recompute is triggered an thus we get our reward
+        discount_line = sale.order_line.filtered("is_reward_line")
+        self.assertEqual(1, len(discount_line), "There should be a reward line")
+        self.assertAlmostEqual(-100, discount_line.price_unit)


### PR DESCRIPTION
This can allow us to work altogether with flexible triggers like the
ones we could need with sale_coupon_criteria_order_based

cc @Tecnativa TT37479