### PR TITLE
[14.0][IMP] sale_coupon_auto_refresh: configurable triggers

### DIFF
--- a/sale_coupon_auto_refresh/README.rst
+++ b/sale_coupon_auto_refresh/README.rst
@@ -40,6 +40,21 @@ You can set this feature on or off in every company. To do so:
 #. Go to *Sales > Configuration > Settings*
 #. In the *Pricing* section you'll find the option *Auto refresh promotions*.
 
+The auto-refresh in the backend is triggered over a minimum set of fields changes. If
+you want to extend the list of that fields:
+
+#. Go to *Settings > Technical > Config parameters*
+#. Add or update the key:
+
+   - For `sale.order`: `sale_coupon_auto_refresh.sale_order_triggers`
+   - For `sale.order.line`: `sale_coupon_auto_refresh.sale_order_line_triggers`
+#. In every add the fields seperated by commas that you want to add to the recomputation
+   triggers.
+
+⚠️ After configuring or removiming a trigger a restart of Odoo is recommended so the
+depends are reloaded properly. Anyway it isn't mandatory and the module detects the
+new triggers so the auto-refresh works as expected as soon as they are set.
+
 Usage
 =====
 

--- a/sale_coupon_auto_refresh/models/sale_order.py
+++ b/sale_coupon_auto_refresh/models/sale_order.py
@@ -32,7 +32,10 @@ class SaleOrder(models.Model):
         self_ctx = self.with_context(skip_auto_refresh_coupons=True)
         res = super(SaleOrder, self_ctx).write(vals)
         new_data = self._read_recs_data()
-        if old_data != new_data:
+        # Until we restart Odoo, we won't get new triggers from params. Once restarted
+        # the method will return an empty set.
+        new_triggers = self._new_trigger()
+        if old_data != new_data or any(x in new_triggers for x in vals):
             self._auto_refresh_coupons()
         return res
 
@@ -90,7 +93,10 @@ class SaleOrderLine(models.Model):
         res = super(SaleOrderLine, self_ctx).write(vals)
         new_data = self._read_recs_data()
         new_orders = self.mapped("order_id")
-        if old_data != new_data:
+        # Until we restart Odoo, we won't get new triggers from params. Once restarted
+        # the method will return an empty set.
+        new_triggers = self._new_trigger()
+        if old_data != new_data or any(x in new_triggers for x in vals):
             (old_orders | new_orders)._auto_refresh_coupons()
         return res
 

--- a/sale_coupon_auto_refresh/readme/CONFIGURE.rst
+++ b/sale_coupon_auto_refresh/readme/CONFIGURE.rst
@@ -2,3 +2,18 @@ You can set this feature on or off in every company. To do so:
 
 #. Go to *Sales > Configuration > Settings*
 #. In the *Pricing* section you'll find the option *Auto refresh promotions*.
+
+The auto-refresh in the backend is triggered over a minimum set of fields changes. If
+you want to extend the list of that fields:
+
+#. Go to *Settings > Technical > Config parameters*
+#. Add or update the key:
+
+   - For `sale.order`: `sale_coupon_auto_refresh.sale_order_triggers`
+   - For `sale.order.line`: `sale_coupon_auto_refresh.sale_order_line_triggers`
+#. In every add the fields seperated by commas that you want to add to the recomputation
+   triggers.
+
+⚠️ After configuring or removiming a trigger a restart of Odoo is recommended so the
+depends are reloaded properly. Anyway it isn't mandatory and the module detects the
+new triggers so the auto-refresh works as expected as soon as they are set.

--- a/sale_coupon_auto_refresh/static/description/index.html
+++ b/sale_coupon_auto_refresh/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Auto Refresh Coupons</title>
 <style type="text/css">
 
@@ -391,6 +391,21 @@ ul.auto-toc {
 <li>Go to <em>Sales &gt; Configuration &gt; Settings</em></li>
 <li>In the <em>Pricing</em> section you’ll find the option <em>Auto refresh promotions</em>.</li>
 </ol>
+<p>The auto-refresh in the backend is triggered over a minimum set of fields changes. If
+you want to extend the list of that fields:</p>
+<ol class="arabic simple">
+<li>Go to <em>Settings &gt; Technical &gt; Config parameters</em></li>
+<li>Add or update the key:<ul>
+<li>For <cite>sale.order</cite>: <cite>sale_coupon_auto_refresh.sale_order_triggers</cite></li>
+<li>For <cite>sale.order.line</cite>: <cite>sale_coupon_auto_refresh.sale_order_line_triggers</cite></li>
+</ul>
+</li>
+<li>In every add the fields seperated by commas that you want to add to the recomputation
+triggers.</li>
+</ol>
+<p>⚠️ After configuring or removiming a trigger a restart of Odoo is recommended so the
+depends are reloaded properly. Anyway it isn’t mandatory and the module detects the
+new triggers so the auto-refresh works as expected as soon as they are set.</p>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#id2">Usage</a></h1>


### PR DESCRIPTION
Forward from 

- #67 

This can allow us to work altogether with flexible triggers like the ones we could need with sale_coupon_criteria_order_based

The auto-refresh in the backend is triggered over a minimum set of fields changes. If you want to extend the list of that fields:

1. Go to *Settings > Technical > Config parameters*
2. Add or update the key:

   - For `sale.order`: `sale_coupon_auto_refresh.sale_order_triggers`
   - For `sale.order.line`: `sale_coupon_auto_refresh.sale_order_line_triggers`
3. In every add the fields seperated by commas that you want to add to the recomputation
   triggers.

⚠️ After configuring or removiming a trigger a restart of Odoo is recommended so the depends are reloaded properly. Anyway it isn't mandatory and the module detects the new triggers so the auto-refresh works as expected as soon as they are set.

cc @Tecnativa TT37691