### PR TITLE
[13.0][FIX] sale_coupon_multiplier_free_product: handle invalid lines

### DIFF
--- a/sale_coupon_multiplier_free_product/models/sale_order.py
+++ b/sale_coupon_multiplier_free_product/models/sale_order.py
@@ -85,15 +85,64 @@ class SaleOrder(models.Model):
                 lambda line: line.coupon_program_id == program and line.is_reward_line
             )
             # Remove reward line if price or qty equal to 0
-            if values.get("product_uom_qty") and values.get("price_unit"):
+            # if values.get("product_uom_qty") and values.get("price_unit"):
+            if values.get("product_uom_qty"):
                 lines.write(values)
             else:
                 lines.unlink()
 
+    def _get_applicable_programs_multiple_of(self):
+        """Wrapper to avoid long method name limitations"""
+        programs = (
+            self._get_applicable_programs() + self._get_valid_applied_coupon_program()
+        )
+        programs = (
+            programs._keep_only_most_interesting_auto_applied_global_discount_program()
+        )
+        return programs
+
     def _remove_invalid_reward_lines(self):
-        """Inject context to avoid removing the wrong lines"""
-        return super(
-            SaleOrder, self.with_context(only_reward_lines=True)
+        """We have to put some logic redundancy here as the main method doesn't have
+        enough granularity to avoid deleting the lines belonging to the multiplier
+        programs when the promotions are updated. So the main module expects that the
+        promotion lines products match with the promotion discount product
+        (https://git.io/JWpoU) , which is not the approach in this module, where we add
+        extra lines with the reward products themselves and the proper price tag and
+        discount. So in this method override, we'll save those correct lines from the
+        fire via context that the unlink method will properly catch. We also have to
+        remove the proper invalid lines that wouldn't be detected"""
+        self.ensure_one()
+        # This part is a repetition of the logic so we can get the right programs
+        applied_programs = self._get_applied_programs()
+        applicable_programs = self.env["sale.coupon.program"]
+        if applied_programs:
+            applicable_programs = self._get_applicable_programs_multiple_of()
+        programs_to_remove = applied_programs - applicable_programs
+        # We're only interested in the Multiplier programs
+        multiple_of_applied_programs = applied_programs.filtered(
+            lambda x: x.reward_type == "multiple_of"
+        )
+        # These will be the ones to keep
+        valid_lines = self.order_line.filtered(
+            lambda x: x.is_reward_line
+            and x.coupon_program_id in multiple_of_applied_programs
+        )
+        multiple_of_programs_to_remove = programs_to_remove.filtered(
+            lambda x: x.reward_type == "multiple_of"
+        )
+        if multiple_of_programs_to_remove:
+            # Invalidate the generated coupons which we are not eligible anymore
+            self.generated_coupon_ids.filtered(
+                lambda x: x.program_id in multiple_of_programs_to_remove
+            ).write({"state": "expired"})
+            # Detect and remove the proper unvalid program order lines
+            self.order_line.filtered(
+                lambda x: x.is_reward_line
+                and x.coupon_program_id in multiple_of_programs_to_remove
+            ).unlink()
+        # We'll catch the context in the subsequent unlink() method
+        super(
+            SaleOrder, self.with_context(valid_multiple_of_lines=valid_lines)
         )._remove_invalid_reward_lines()
 
 
@@ -106,13 +155,13 @@ class SaleOrderLine(models.Model):
         return super(SaleOrderLine, self.filtered("is_reward_line")).write(vals)
 
     def unlink(self):
-        reward_lines = self.filtered("is_reward_line").exists()
-        for line in reward_lines:
-            related_program = self.env["sale.coupon.program"].search(
-                [("reward_product_id", "=", line.product_id.id)]
-            )
-            line.order_id.no_code_promo_program_ids -= related_program
-            line.order_id.code_promo_program_id -= related_program
-        if not self.env.context.get("only_reward_lines"):
-            return super(SaleOrderLine, self.exists()).unlink()
-        return super(SaleOrderLine, reward_lines).unlink()
+        """Avoid unlinking valid multiplier lines since they aren't linked to the
+        discount product of the promotion program"""
+        if not self.env.context.get("valid_multiple_of_lines"):
+            return super().unlink()
+        return super(
+            SaleOrderLine,
+            self.filtered(
+                lambda x: x not in self.env.context.get("valid_multiple_of_lines")
+            ),
+        ).unlink()

--- a/sale_coupon_multiplier_free_product/tests/test_website_sale_coupon_free_product.py
+++ b/sale_coupon_multiplier_free_product/tests/test_website_sale_coupon_free_product.py
@@ -60,6 +60,8 @@ class TestSaleCouponMultiplier(common.SavepointCase):
             line_form.product_id = cls.product_1
             line_form.product_uom_qty = 2
         cls.sale = sale_form.save()
+        # Shortcut helper
+        cls.apply_coupon = cls.env["sale.coupon.apply.code"].sudo().apply_coupon
 
     def test_sale_coupon_test_3x2(self):
         """As we fulfill the proper product qties, we get the proper free product"""
@@ -149,3 +151,75 @@ class TestSaleCouponMultiplier(common.SavepointCase):
         discount_line = sale.order_line.filtered("is_reward_line")
         self.assertEqual(3, discount_line.product_uom_qty)
         self.assertEqual(0, discount_line.price_reduce)
+
+    def test_coupon_progam_3x2(self):
+        """Test coupons for this case"""
+        self.coupon_program.program_type = "coupon_program"
+        self.coupon_program.promo_code_usage = "code_needed"
+        self.env["sale.coupon.generate"].with_context(
+            active_id=self.coupon_program.id
+        ).create({"generation_type": "nbr_coupon", "nbr_coupons": 1}).generate_coupon()
+        coupon = self.coupon_program.coupon_ids
+        self.assertEqual(coupon.state, "new")
+        # No discount until we apply the code
+        self.sale.recompute_coupon_lines()
+        discount_line = self.sale.order_line.filtered("is_reward_line")
+        sale_line = self.sale.order_line
+        self.assertFalse(bool(discount_line))
+        self.apply_coupon(self.sale, coupon.code)
+        # The discount is applied
+        discount_line = self.sale.order_line.filtered("is_reward_line")
+        self.assertTrue(bool(discount_line))
+        # The discount remains
+        self.sale.recompute_coupon_lines()
+        discount_line = self.sale.order_line.filtered("is_reward_line")
+        self.assertTrue(bool(discount_line))
+        self.assertEqual(coupon.state, "used")
+        # The coupon isn't applicable anymore
+        sale_line.product_uom_qty = 1
+        self.sale.recompute_coupon_lines()
+        discount_line = self.sale.order_line.filtered("is_reward_line")
+        self.assertFalse(bool(discount_line))
+        self.assertEqual(coupon.state, "new")
+
+    def test_coupon_buy_a_product_get_this_other_free(self):
+        """For every 2 of any product, we get the rewarded product for free"""
+        self.coupon_program.force_rewarded_product = False
+        self.coupon_program.program_type = "coupon_program"
+        self.coupon_program.promo_code_usage = "code_needed"
+        self.env["sale.coupon.generate"].with_context(
+            active_id=self.coupon_program.id
+        ).create({"generation_type": "nbr_coupon", "nbr_coupons": 1}).generate_coupon()
+        coupon = self.coupon_program.coupon_ids
+        self.assertEqual(coupon.state, "new")
+        # Let's create a new sale
+        sale_form = Form(self.env["sale.order"])
+        sale_form.partner_id = self.partner
+        with sale_form.order_line.new() as line_form:
+            line_form.product_id = self.product_2
+            line_form.product_uom_qty = 2
+            line_form.price_unit = 50
+        sale = sale_form.save()
+        sale_line = sale.order_line
+        sale.recompute_coupon_lines()
+        discount_line = sale.order_line.filtered("is_reward_line")
+        # We should apply the coupon first
+        self.assertFalse(bool(discount_line))
+        self.apply_coupon(sale, coupon.code)
+        discount_line = sale.order_line.filtered("is_reward_line")
+        # We bought 2 x product_2 and get 1x product_1
+        self.assertEqual(self.product_1, discount_line.product_id)
+        self.assertEqual(coupon.state, "used")
+        self.assertEqual(1, discount_line.product_uom_qty)
+        self.assertEqual(0, discount_line.price_reduce)
+        self.assertEqual(50, discount_line.price_unit)
+        # The product could come with a 100% discount
+        self.product_1.list_price = 0
+        # We bought 5 x product_2 and get 2x product_1
+        sale_line.product_uom_qty = 5
+        sale.recompute_coupon_lines()
+        discount_line = sale.order_line.filtered("is_reward_line")
+        self.assertEqual(self.product_1, discount_line.product_id)
+        self.assertEqual(2, discount_line.product_uom_qty)
+        self.assertEqual(0, discount_line.price_unit)
+        self.assertEqual(coupon.state, "used")


### PR DESCRIPTION
We have to put some logic redundancy here as the main method doesn't have enough granularity to avoid deleting the lines belonging to the multiplier programs when the promotions are updated. So the main module expects that the promotion lines products match with the promotion discount product (https://git.io/JWpoU) , which is not the approach in this module, where we add extra lines with the reward products themselves and the proper price tag and discount. So in this method override, we'll save those correct lines from the fire via context that the unlink method will properly catch. We also have to remove the proper invalid lines that wouldn't be detected.

cc @Tecnativa TT38806

please review @victoralmau @pedrobaeza 