### PR TITLE
[13.0][FIX] sale_coupon_auto_refresh: safely apply coupons

### DIFF
--- a/sale_coupon_auto_refresh/wizard/sale_coupon_apply_code.py
+++ b/sale_coupon_auto_refresh/wizard/sale_coupon_apply_code.py
@@ -7,3 +7,9 @@ class SaleCouponApplyCode(models.TransientModel):
     def process_coupon(self):
         wiz = self.with_context(skip_auto_refresh_coupons=True)
         return super(SaleCouponApplyCode, wiz).process_coupon()
+
+    def apply_coupon(self, order, coupon_code):
+        """Avoid discarding the coupon before the end of the process"""
+        return super().apply_coupon(
+            order.with_context(skip_auto_refresh_coupons=True), coupon_code
+        )


### PR DESCRIPTION
We should not refresh the lines before the proccess of applying the coupon is finished.

cc @Tecnativa TT38806