### PR TITLE
[14.0][IMP] sale_promotion_discount_if_field: compatibility with product exclude module

### DIFF
--- a/sale_promotion_discount_in_field/models/sale_order.py
+++ b/sale_promotion_discount_in_field/models/sale_order.py
@@ -21,6 +21,9 @@ class SaleOrder(models.Model):
         """
         Set discount for order lines
         """
+        # this context is used for compatibility with the
+        # sale_coupone_product_exclude_module
+        self = self.with_context(current_coupon_program=program)
         if program.discount_apply_on == "cheapest_product":
             lines = self._get_cheapest_line()
         else:


### PR DESCRIPTION
This fix is necessary for compatibility with the module sale_coupon_product_exclude from https://github.com/OCA/sale-promotion/pull/74