### PR TITLE
[14.0][FIX] sale_coupon_order_line_link: missing links

### DIFF
--- a/sale_coupon_order_line_link/models/sale_order.py
+++ b/sale_coupon_order_line_link/models/sale_order.py
@@ -121,6 +121,12 @@ class SaleOrder(models.Model):
                 {"reward_generated_line_ids": [(4, rl.id) for rl in reward_lines]}
             )
 
+    def _create_new_no_code_promo_reward_lines(self):
+        """Ensure that the links remain"""
+        super()._create_new_no_code_promo_reward_lines()
+        for order in self:
+            order._link_reward_generated_lines(order.order_line.coupon_program_id)
+
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"


### PR DESCRIPTION
- Fw of #82 

In some cases the `recompute_coupon_lines` method could lead to miss the previously created links. We want to ensure those links at the end of such method.

cc @Tecnativa TT40205

please review @victoralmau @CarlosRoca13 