### PR TITLE
[15.0][FIX] sale_coupon_financial_risk: fix test_sale_coupon_financial_risk

### DIFF
--- a/sale_coupon_financial_risk/tests/test_sale_coupon_financial_risk.py
+++ b/sale_coupon_financial_risk/tests/test_sale_coupon_financial_risk.py
@@ -8,7 +8,7 @@ class TestSaleCouponFinancialRisk(common.TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.env.user.groups_id |= cls.env.ref(
-            "account_financial_risk.group_overpass_partner_risk_exception"
+            "account_financial_risk.group_account_financial_risk_manager"
         )
         cls.partner = cls.env["res.partner"].create(
             {"name": "Partner", "email": "demo@demo.com"}


### PR DESCRIPTION
"account_financial_risk.group_overpass_partner_risk_exception" has been renamed to "account_financial_risk.group_account_financial_risk_manager".
https://github.com/OCA/credit-control/blob/15.0/account_financial_risk/migrations/15.0.1.6.0/pre-migration.py#L6

cc @Tecnativa TT45749

@pedrobaeza @chienandalu please review