### PR TITLE
[16.0][FIX] sale_loyalty_partner_applicability: correct domain evaluation

### DIFF
--- a/sale_loyalty_partner_applicability/models/sale_order.py
+++ b/sale_loyalty_partner_applicability/models/sale_order.py
@@ -40,7 +40,7 @@ class SaleOrder(models.Model):
         """
         for rule in program.rule_ids:
             partner_domain = self._get_partner_domain(rule, self.partner_id)
-            if partner_domain and self.env["res.partner"].search_count(partner_domain):
+            if self.env["res.partner"].search_count(partner_domain):
                 return True
         return False
 


### PR DESCRIPTION
This condition is erroneous since in case partner_domain is [ ] it will be evaluated as False and therefore will not fulfil the condition.

cc @Tecnativa TT44347

@chienandalu @pedrobaeza please review