### PR TITLE
[16.0][FIX] loyalty_partner_applicability: Set default value for partner domain rule

### DIFF
--- a/loyalty_partner_applicability/models/loyalty_rule.py
+++ b/loyalty_partner_applicability/models/loyalty_rule.py
@@ -1,6 +1,6 @@
 # Copyright 2023 Tecnativa - Pilar Vargas
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class LoyaltyRule(models.Model):
@@ -12,3 +12,11 @@ class LoyaltyRule(models.Model):
         help="Loyalty program will work for selected customers only",
         default="[]",
     )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        res = super().create(vals_list)
+        for vals in vals_list:
+            if not vals.get("rule_partners_domain", False):
+                vals["rule_partners_domain"] = "[]"
+        return res

--- a/sale_loyalty_partner_applicability/models/sale_order.py
+++ b/sale_loyalty_partner_applicability/models/sale_order.py
@@ -11,7 +11,7 @@ class SaleOrder(models.Model):
 
     def _get_partner_domain(self, rule, partner_id):
         domain = []
-        if rule.rule_partners_domain != "[]":
+        if rule.rule_partners_domain and rule.rule_partners_domain != "[]":
             allow_sharing = (
                 self.env["ir.config_parameter"].sudo().get_param("allow_coupon_sharing")
             )


### PR DESCRIPTION
It is necessary to set the default value, in this case "[ ]" to the rule_partners_domain field, overwriting the computed method "_program_type_default_values" that sets the default values depending on the type of program, because when creating a new program, these default rules are defined and the rule_partners_domain field, not being contemplated, its value will be "False", which cannot be interpreted as a correct domain. To avoid this error, the value is added to the rules defined by default.

The error:
![image](https://github.com/OCA/sale-promotion/assets/118818446/8ca6fb15-dfa6-414b-8cf1-fc2acdbf2913)


cc @Tecnativa TT44344

@chienandalu @CarlosRoca13 please review