### PR TITLE
[15.0][FIX] sale_coupon_criteria_order_based: Add tagged "post_install" to tests

### DIFF
--- a/sale_coupon_criteria_order_based/tests/test_sale_coupon_criteria_order_based.py
+++ b/sale_coupon_criteria_order_based/tests/test_sale_coupon_criteria_order_based.py
@@ -1,9 +1,12 @@
 # Copyright 2022 Ooops404
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from odoo.tests import tagged
+
 from odoo.addons.sale_coupon.tests.common import TestSaleCouponCommon
 
 
+@tagged("post_install", "-at_install")
 class TestSaleCouponCriteriaOrderBased(TestSaleCouponCommon):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
This test requires a CoA to be installed, it should be tagged "post_install"

cc @Tecnativa TT46134

@pedrobaeza @CarlosRoca13 please review