### PR TITLE
[ADD] gift_card_limited_to & website_sale_gift_card_limited_to

### DIFF
--- a/gift_card_limited_to/__init__.py
+++ b/gift_card_limited_to/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/gift_card_limited_to/__manifest__.py
+++ b/gift_card_limited_to/__manifest__.py
@@ -1,0 +1,20 @@
+# Copyright 2024 Moka Tourisme
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    'name': 'Gift Card limited to',
+    'version': '15.0.1.0.0',
+    'author' : 'Moka Tourisme',
+    "website": "https://www.mokatourisme.fr",
+    'description' : "Limite l'utilisation des cartes cadeaux sur des articles",
+    'category': 'Sales',
+    "license": "AGPL-3",
+    'summary': 'Gift card personalisation module',
+    'depends': ['gift_card', 'point_of_sale', 'sale'],
+    'data': [
+        'views/gift_card_view.xml',
+        'views/gift_card_design_templates.xml'
+    ],
+    'installable': True,
+    'application': True,
+    'auto_install': False,
+}

--- a/gift_card_limited_to/models/__init__.py
+++ b/gift_card_limited_to/models/__init__.py
@@ -1,0 +1,4 @@
+from . import product_template_inherit
+from . import gift_card_inherit
+from . import pos_order_line_inherit
+from . import sale_order_line_inherit

--- a/gift_card_limited_to/models/gift_card_inherit.py
+++ b/gift_card_limited_to/models/gift_card_inherit.py
@@ -1,0 +1,6 @@
+from odoo import fields, models
+
+class GiftCardCustom(models.Model):
+    _inherit = "gift.card"
+
+    limited_to_product_id = fields.Many2one('product.template', string="Limited to")

--- a/gift_card_limited_to/models/pos_order_line_inherit.py
+++ b/gift_card_limited_to/models/pos_order_line_inherit.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from dateutil.relativedelta import relativedelta
+from odoo import fields, models
+
+
+class PosOrderLine(models.Model):
+    _inherit = "pos.order.line"
+
+    def _build_gift_card(self):
+        gift_card = super()._build_gift_card()
+        gift_card['limited_to_product_id'] = self.product_id.product_tmpl_id.limited_to_product_id.id
+        return gift_card

--- a/gift_card_limited_to/models/product_template_inherit.py
+++ b/gift_card_limited_to/models/product_template_inherit.py
@@ -1,0 +1,6 @@
+from odoo import fields, models
+
+class ProductTemplateCustom(models.Model):
+    _inherit = "product.template"
+
+    limited_to_product_id = fields.Many2one('product.template', string="Limited to")

--- a/gift_card_limited_to/models/sale_order_line_inherit.py
+++ b/gift_card_limited_to/models/sale_order_line_inherit.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from dateutil.relativedelta import relativedelta
+from odoo import _, api, fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    def _build_gift_card(self):
+        gift_card = super()._build_gift_card()
+        print("YOUHOU")
+        gift_card['limited_to_product_id'] = self.product_template_id.limited_to_product_id.id
+        return gift_card

--- a/gift_card_limited_to/readme.rst
+++ b/gift_card_limited_to/readme.rst
@@ -1,0 +1,36 @@
+gift_card_limited_to
+=========
+
+This module allows you to limit the use of gift cards to a single item. This module must be associated with website_sale_gift_card_limited_to work on the website. 
+
+In the gift card configuration, a field appears: limited to. This field is used to specify an item on which the gift card can be used. 
+This field will also be retrieved in the backend when the card is sold at the point of sale and/or when a quote is made.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/Moka-Tourisme/sale-promotion/issues>`
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us to smash it by providing a detailed and welcomed feedback.
+
+
+Do not contact contributors directly about support or help with technical issues.
+
+Credits
+=======
+
+## Authors
+
+* Moka Tourisme 
+
+## Contributors
+
+* Horvat Damien : `<https://github.com/PlantBasedStudio>`
+* Duciel Romain : `<https://github.com/Rom10811>`
+
+## Maintainers
+This module is maintained by Moka Tourisme.
+
+
+This module is a addon for the `Odoo/addons/gift_card <https://github.com/odoo/odoo/tree/15.0/addons/gift_card>` project on GitHub.
+You are welcome to contribute. To learn how please visit https://odoo-community.org/page/Contribute.

--- a/gift_card_limited_to/views/gift_card_design_templates.xml
+++ b/gift_card_limited_to/views/gift_card_design_templates.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="page_gift_card_view_form" model="ir.ui.view">
+        <field name="name">page.gift.card.form Website</field>
+        <field name="model">gift.card</field>
+        <field name="inherit_id" ref="gift_card.gift_card_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='gift_card']" position="inside">
+                <field name="limited_to_product_id"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/gift_card_limited_to/views/gift_card_view.xml
+++ b/gift_card_limited_to/views/gift_card_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<odoo>
+    <record id="gift_card_view_form" model="ir.ui.view">
+        <field name="name">product.template.view_form</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='group_general']" position="inside">
+                <field name="limited_to_product_id"/>  
+            </xpath>
+        </field>      
+    </record>
+</odoo>

--- a/website_sale_gift_card_limited_to/__init__.py
+++ b/website_sale_gift_card_limited_to/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import controllers

--- a/website_sale_gift_card_limited_to/__manifest__.py
+++ b/website_sale_gift_card_limited_to/__manifest__.py
@@ -1,0 +1,19 @@
+# Copyright 2024 Moka Tourisme
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    'name': 'Website Sale Gift Card limited to',
+    'version': '15.0.1.0.0',
+    'author' : 'Moka Tourisme',
+    "website": "https://www.mokatourisme.fr",
+    'description' : "Limite l'utilisation des cartes cadeaux sur un article en site web",
+    'category': 'Sales',
+    "license": "AGPL-3",
+    'summary': 'Gift card personalisation module',
+    'depends': ['website_sale_gift_card', 'gift_card_limited_to', 'sale_gift_card'],
+    'data': [
+        
+    ],
+    'installable': True,
+    'application': True,
+    'auto_install': False,
+}

--- a/website_sale_gift_card_limited_to/controllers/__init__.py
+++ b/website_sale_gift_card_limited_to/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import gift_card_controller_inherit

--- a/website_sale_gift_card_limited_to/controllers/gift_card_controller_inherit.py
+++ b/website_sale_gift_card_limited_to/controllers/gift_card_controller_inherit.py
@@ -1,0 +1,13 @@
+from odoo import http
+from odoo.http import request
+from odoo.addons.website_sale.controllers import main
+
+
+class GiftCardController(main.WebsiteSale):
+
+    @http.route('/shop/pay_with_gift_card', type='http', methods=['POST'], website=True, auth='public')
+    def add_gift_card(self, gift_card_code, **post):
+        gift_card = request.env["gift.card"].sudo().search([('code', '=', gift_card_code.strip())], limit=1)
+        order = request.env['website'].get_current_website().sale_get_order()
+        gift_card_status = order._pay_with_gift_card(gift_card)
+        return request.redirect('/shop/payment' + '?keep_carrier=1' + ('&gift_card_error=%s' % gift_card_status if gift_card_status else ''))

--- a/website_sale_gift_card_limited_to/models/__init__.py
+++ b/website_sale_gift_card_limited_to/models/__init__.py
@@ -1,0 +1,1 @@
+from . import sale_order_inherit

--- a/website_sale_gift_card_limited_to/models/sale_order_inherit.py
+++ b/website_sale_gift_card_limited_to/models/sale_order_inherit.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import _, api, fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    def _pay_with_gift_card(self, gift_card):
+        error = False
+
+        if not gift_card.can_be_used():
+            error = _('Invalid or Expired Gift Card.')
+        elif gift_card in self.order_line.mapped("gift_card_id"):
+            error = _('Gift Card already used.')
+        elif gift_card.partner_id and gift_card.partner_id != self.env.user.partner_id:
+            error = _('Gift Card are restricted for another user.')
+        elif gift_card.limited_to_product_id not in self.order_line.mapped('product_id.product_tmpl_id'):
+            error = _('Gift Card restricted to specific product.')
+
+        amount = min(self.amount_total, gift_card.balance_converted(self.currency_id))
+        if not error and amount > 0:
+            pay_gift_card_id = self.env.ref('gift_card.pay_with_gift_card_product')
+            gift_card.redeem_line_ids.filtered(lambda redeem: redeem.state != "sale").unlink()
+            self.env["sale.order.line"].create({
+                'product_id': pay_gift_card_id.id,
+                'price_unit': - amount,
+                'product_uom_qty': 1,
+                'product_uom': pay_gift_card_id.uom_id.id,
+                'gift_card_id': gift_card.id,
+                'order_id': self.id
+            })
+        return error

--- a/website_sale_gift_card_limited_to/readme.rst
+++ b/website_sale_gift_card_limited_to/readme.rst
@@ -1,0 +1,37 @@
+website_sale_gift_card_limited_to
+=========
+
+This module allows you to sell an item using a gift card only if that gift card is used to sell that item. 
+When the gift card code is validated, the module will check whether the card is valid for the items in the basket. 
+
+This module works with gift_card_limited_to, which allows you to add an item limit to a gift card. 
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/Moka-Tourisme/sale-promotion/issues>`
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us to smash it by providing a detailed and welcomed feedback.
+
+
+Do not contact contributors directly about support or help with technical issues.
+
+Credits
+=======
+
+## Authors
+
+* Moka Tourisme 
+
+## Contributors
+
+* Horvat Damien : `<https://github.com/PlantBasedStudio>`
+* Duciel Romain : `<https://github.com/Rom10811>`
+
+## Maintainers
+This module is maintained by OCA.
+
+
+This module is a addon for the `Odoo/addons/gift_card <https://github.com/odoo/odoo/tree/15.0/addons/website_sale_gift_card>` project on GitHub.
+You are welcome to contribute. To learn how please visit https://odoo-community.org/page/Contribute.


### PR DESCRIPTION
Hello, 

I'd like to suggest these two modules that allow you to limit the use of a gift card on an item. 
When the customer uses it on the website, the site returns an error if the item linked to this card is not in the customer's basket. 

I'd like to extend this functionality to a category of item at a later date. 

This is my first contribution to OCA, so please let me know what you think.