### PR TITLE
[16.0][IMP] sale_loyalty_order_suggestion: Add hook method

### DIFF
--- a/sale_loyalty_order_suggestion/static/src/js/suggest_promotion_widget.esm.js
+++ b/sale_loyalty_order_suggestion/static/src/js/suggest_promotion_widget.esm.js
@@ -16,6 +16,7 @@ export class SuggestPromotionWidget extends Component {
     }
 
     async viewPromotionsWizard() {
+        const productId = this.props.record.data.product_id[0];
         const SuggestedPromotions = this.getSuggestedPromotions();
         const record = this.__owl__.parent.parent.parent.props.record;
         await record.save();
@@ -23,6 +24,7 @@ export class SuggestPromotionWidget extends Component {
             additionalContext: {
                 default_active_id: record.data.id,
                 default_order_id: record.data.id,
+                default_product_id: productId,
                 default_reward_ids: SuggestedPromotions,
             },
         });

--- a/sale_loyalty_order_suggestion/wizard/sale_loyalty_reward_wizard.py
+++ b/sale_loyalty_order_suggestion/wizard/sale_loyalty_reward_wizard.py
@@ -5,6 +5,7 @@ class SaleLoyaltyRewardWizard(models.TransientModel):
     _inherit = "sale.loyalty.reward.wizard"
     _description = "Sale Loyalty - Reward Selection Wizard"
 
+    product_id = fields.Many2one("product.product")
     # To ensure whether the selected promotion satisfies your rules and is directly
     # applicable or needs to satisfy your rules to be applied.
     applicable_program = fields.Boolean(
@@ -34,6 +35,7 @@ class SaleLoyaltyRewardWizard(models.TransientModel):
 
     @api.depends("selected_reward_id")
     def _compute_loyalty_rule_line_ids(self):
+        self.loyalty_rule_line_ids = None
         units_required = min(
             self.selected_reward_id.program_id.rule_ids.mapped("minimum_qty"), default=0
         )
@@ -65,8 +67,6 @@ class SaleLoyaltyRewardWizard(models.TransientModel):
                     )
                 )
             self.loyalty_rule_line_ids = lines_vals
-        else:
-            self.loyalty_rule_line_ids = None
 
     @api.depends_context("lang")
     @api.depends("selected_reward_id")

--- a/sale_loyalty_order_suggestion/wizard/sale_loyalty_reward_wizard_views.xml
+++ b/sale_loyalty_order_suggestion/wizard/sale_loyalty_reward_wizard_views.xml
@@ -8,6 +8,7 @@
         />
         <field name="arch" type="xml">
             <field name="selected_product_id" position="after">
+                <field name="product_id" invisible="1" />
                 <field name="applicable_program" invisible="1" />
                 <field
                     name="loyalty_rule_line_description"


### PR DESCRIPTION
Add hook method to help communicate this module with other modules that extend it by returning records from programs whose rules are based on products before filtering by order product and avoid extra modules that will not provide any functionality.

cc @Tecnativa TT48349

@chienandalu @pedrobaeza please review