### PR TITLE
[16.0][FIX] compute suggested_promotions when no product in so line

### DIFF
--- a/sale_loyalty_order_suggestion/models/sale_order.py
+++ b/sale_loyalty_order_suggestion/models/sale_order.py
@@ -119,6 +119,7 @@ class SaleOrderLine(models.Model):
     def _compute_suggested_promotion_ids(self):
         self.suggested_promotion_ids = False
         self.suggested_reward_ids = False
+        self.suggested_promotions = False
         for line in self.filtered("product_id"):
             line.suggested_promotion_ids = line.order_id.with_context(
                 product_id=line.product_id.id


### PR DESCRIPTION
In some cases, line of a sale order not have product_id and an error occurs for computing suggested_promotions field. 