### PR TITLE
[16.0][FIX] loyalty_limit: Remove o2m field from SQL query in migration script

### DIFF
--- a/loyalty_limit/migrations/16.0.1.0.0/pre-migration.py
+++ b/loyalty_limit/migrations/16.0.1.0.0/pre-migration.py
@@ -58,13 +58,6 @@ def migrate(env, version):
         env.cr,
         """
         ALTER TABLE loyalty_program
-        ADD COLUMN IF NOT EXISTS salesmen_limit_ids INT
-        """,
-    )
-    openupgrade.logged_query(
-        env.cr,
-        """
-        ALTER TABLE loyalty_program
         ADD COLUMN IF NOT EXISTS salesmen_strict_limit BOOLEAN
         """,
     )
@@ -74,7 +67,6 @@ def migrate(env, version):
         UPDATE loyalty_program AS lp
         SET
             max_customer_application = lr.rule_max_customer_application,
-            salesmen_limit_ids = lr.rule_salesmen_limit_ids,
             salesmen_strict_limit = lr.rule_salesmen_strict_limit
         FROM loyalty_rule AS lr
         WHERE lp.id = lr.program_id


### PR DESCRIPTION
The o2m field is linked to the corresponding table via the program_id field, which is already defined in the script and also the way to get the data. An o2m field does not exist in the database, it is a relation.

cc @Tecnativa

@pedrobaeza @carolinafernandez-tecnativa please review