### PR TITLE
[16.0][FIX] sale_loyalty_order_line_link: Fix SQL query of migration script.

### DIFF
--- a/sale_loyalty_order_line_link/migrations/16.0.1.0.0/pre-migration.py
+++ b/sale_loyalty_order_line_link/migrations/16.0.1.0.0/pre-migration.py
@@ -26,7 +26,7 @@ def migrate(env, version):
         env.cr,
         """
         UPDATE sale_order_line AS sol
-        SET sol.reward_id = lr.id
+        SET reward_id = lr.id
         FROM loyalty_reward AS lr
         WHERE sol.loyalty_program_id = lr.program_id;
         """,


### PR DESCRIPTION
The alias in front of the column to be modified causes a conflict and is wrong.

```
column "sol" of relation "sale_order_line" does not exist
             SET sol.reward_id = lr.id
```

cc @Tecnativa

@pedrobaeza @chienandalu please review