### PR TITLE
[16.0][FIX] loyalty_criteria_multi_product: Complete loyalty_rule table data

### DIFF
--- a/loyalty_criteria_multi_product/migrations/16.0.1.0.0/pre-migration.py
+++ b/loyalty_criteria_multi_product/migrations/16.0.1.0.0/pre-migration.py
@@ -19,10 +19,9 @@ def move_coupon_criteria_to_rule(env):
         env.cr,
         """
         UPDATE loyalty_rule AS lr
-        SET loyalty_criteria = 'multi_product'
+        SET loyalty_criteria = lp.coupon_criteria
         FROM loyalty_program AS lp
         WHERE lr.program_id = lp.id
-        AND lp.coupon_criteria = 'multi_product'
         """,
     )
     # coupon_criteria_ids to loyalty_criteria_ids


### PR DESCRIPTION
The loyalty_criteria field data, previously in the loyalty_program table (coupon_program) must be moved completely, both the value 'multi_product' and 'domain' to the loyalty_rule table where this data must now be stored. Otherwise the data 'domain' will be lost.

cc @Tecnativa TT44317

@chienandalu @pedrobaeza please review