### PR TITLE
[16.0][FIX] loyalty_multi_gift: Transfer m2m data to new table

### DIFF
--- a/loyalty_multi_gift/migrations/16.0.1.0.0/post-migration.py
+++ b/loyalty_multi_gift/migrations/16.0.1.0.0/post-migration.py
@@ -1,0 +1,16 @@
+# Copyright 2024 Tecnativa - Pilar Vargas
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        INSERT INTO loyalty_reward_product_line_product_product_rel
+            (loyalty_reward_product_line_id, product_product_id)
+        SELECT coupon_reward_product_line_id, product_product_id
+        FROM coupon_reward_product_line_product_product_rel
+        """,
+    )


### PR DESCRIPTION
By changing the name of the template, the relationship table of the
field "reward_product_ids" with the template "loyalty.reward.product_line" formerly "coupon.reward.product_line" changes so the data from the old table has to be moved to the new one.

cc @Tecnativa TT44321

@chienandalu @pedrobaeza please review