### PR TITLE
[14.0][FIX]sale_coupon_delivery_auto_refresh: set context only for coupons

### DIFF
--- a/sale_coupon_delivery_auto_refresh/README.rst
+++ b/sale_coupon_delivery_auto_refresh/README.rst
@@ -84,6 +84,7 @@ Contributors
 ~~~~~~~~~~~~
 
 * Ooops404 <https://www.ooops404.com/>
+  * Eduard Brahas <eduard@ooops404.com>
 * Cetmix <https://cetmix.com/>
 
 Maintainers

--- a/sale_coupon_delivery_auto_refresh/models/sale_order.py
+++ b/sale_coupon_delivery_auto_refresh/models/sale_order.py
@@ -9,9 +9,7 @@ class SaleOrder(models.Model):
         Override to change context value to refresh coupons after creation
         delivery line
         """
-        self = self.with_context(
-            skip_auto_refresh_coupons=False, auto_refresh_delivery=True
-        )
+        self = self.with_context(skip_auto_refresh_coupons=False)
         return super(SaleOrder, self)._auto_refresh_delivery()
 
     def _create_delivery_line(self, carrier, price_unit):

--- a/sale_coupon_delivery_auto_refresh/readme/CONTRIBUTORS.rst
+++ b/sale_coupon_delivery_auto_refresh/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Ooops404 <https://www.ooops404.com/>
+  * Eduard Brahas <eduard@ooops404.com>
 * Cetmix <https://cetmix.com/>

--- a/sale_coupon_delivery_auto_refresh/static/description/index.html
+++ b/sale_coupon_delivery_auto_refresh/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -429,14 +430,17 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="contributors">
 <h1>Contributors</h1>
 <ul class="simple">
-<li>Ooops404 &lt;<a class="reference external" href="https://www.ooops404.com/">https://www.ooops404.com/</a>&gt;</li>
+<li>Ooops404 &lt;<a class="reference external" href="https://www.ooops404.com/">https://www.ooops404.com/</a>&gt;
+* Eduard Brahas &lt;<a class="reference external" href="mailto:eduard&#64;ooops404.com">eduard&#64;ooops404.com</a>&gt;</li>
 <li>Cetmix &lt;<a class="reference external" href="https://cetmix.com/">https://cetmix.com/</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
 <h1>Maintainers</h1>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/sale_coupon_delivery_auto_refresh/tests/test_sale_coupon_delivery_auto_refresh.py
+++ b/sale_coupon_delivery_auto_refresh/tests/test_sale_coupon_delivery_auto_refresh.py
@@ -29,18 +29,15 @@ class TestDeliveryAutoRefresh(common.SavepointCase):
                 "property_product_pricelist": pricelist.id,
             }
         )
-        cls.env["ir.config_parameter"].sudo().set_param(
-            "delivery_auto_refresh.set_default_carrier", 1
-        )
-        cls.env["ir.config_parameter"].sudo().set_param(
-            "delivery_auto_refresh.auto_void_delivery_line", 1
-        )
-        cls.env["ir.config_parameter"].sudo().set_param(
-            "delivery_auto_refresh.refresh_after_picking", 1
-        )
-        cls.env["ir.config_parameter"].sudo().set_param(
-            "delivery_auto_refresh.auto_add_delivery_line", 1
-        )
+        cls.env["res.config.settings"].create(
+            {
+                "sale_auto_assign_carrier_on_create": True,
+                "sale_auto_add_delivery_line": True,
+                "sale_refresh_delivery_after_picking": True,
+                "sale_auto_void_delivery_line": True,
+            }
+        ).execute()
+
         coupon_program_form = Form(
             cls.env["coupon.program"],
             view="sale_coupon.sale_coupon_program_view_promo_program_form",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,1 @@
+ odoo14-addon-delivery_auto_refresh @ git+https://github.com/OCA/delivery-carrier.git@refs/pull/849/head#subdirectory=setup/delivery_auto_refresh


### PR DESCRIPTION
Fix needed for this PR: https://github.com/OCA/delivery-carrier/pull/849.