### PR TITLE
[16.0][FIX] loyalty_criteria_multi_product: Avoiding cross-data in multi-product promotion criteria

### DIFF
--- a/loyalty_criteria_multi_product/models/loyalty_rule.py
+++ b/loyalty_criteria_multi_product/models/loyalty_rule.py
@@ -24,7 +24,10 @@ class LoyaltyRule(models.Model):
     def _onchange_loyalty_criteria(self):
         """Clear domain so we clear some other fields from the view"""
         if self.loyalty_criteria == "multi_product":
+            self.minimum_amount = 0.00
             self.product_domain = False
             self.product_ids = False
             self.product_category_id = False
             self.product_tag_id = False
+        else:
+            self.loyalty_criteria_ids = False

--- a/loyalty_criteria_multi_product/views/loyalty_rule_views.xml
+++ b/loyalty_criteria_multi_product/views/loyalty_rule_views.xml
@@ -9,6 +9,21 @@
                     name="attrs"
                 >{'invisible': [('loyalty_criteria', '!=', 'domain')]}</attribute>
             </field>
+            <field name="minimum_amount" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'invisible': [('loyalty_criteria', '!=', 'domain')]}</attribute>
+            </field>
+            <label for="minimum_amount" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'invisible': [('loyalty_criteria', '!=', 'domain')]}</attribute>
+            </label>
+            <div class="d-flex flex-row" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'invisible': [('loyalty_criteria', '!=', 'domain')]}</attribute>
+            </div>
             <field name="product_domain" position="attributes">
                 <attribute
                     name="attrs"


### PR DESCRIPTION
When setting up a multi-product promotion, you should not set a minimum spend amount because if one rule passes, they will all pass. To avoid misconfiguration, the field is hidden for promotions with multi-product criteria. In addition, the rule data is cleared when the criterion is changed so that the promotion is applied correctly in case of promotion modifications.

cc @Tecnativa

@carlos-lopez-tecnativa @chienandalu please review