### PR TITLE
[16.0][FIX] sale_loyalty_limit: fail on new record

### DIFF
--- a/sale_loyalty_limit/models/sale_order.py
+++ b/sale_loyalty_limit/models/sale_order.py
@@ -14,7 +14,7 @@ class SaleOrder(models.Model):
             if program.max_customer_application:
                 customer_domain = [
                     ("order_line.loyalty_program_id", "=", program.id),
-                    ("id", "!=", self.id),
+                    ("id", "!=", self._origin.id),
                     (
                         "commercial_partner_id",
                         "=",
@@ -68,7 +68,7 @@ class SaleOrder(models.Model):
                                 salesman_rule.user_id.id,
                             ),
                             ("order_id.state", "!=", "cancel"),
-                            ("order_id", "!=", self.id),
+                            ("order_id", "!=", self._origin.id),
                         ],
                         ["order_id"],
                         ["order_id"],


### PR DESCRIPTION
Avoid search on a new record id (NewIdxxxx) as it will fail on the query parsin to the db.

cc @Tecnativa TT52185

please review @pilarvargas-tecnativa @carlos-lopez-tecnativa 