### PR TITLE
[16.0][FIX] sale_loyalty_auto_refresh: Ensure create record are returned in…

### DIFF
--- a/sale_loyalty_auto_refresh/models/sale_order.py
+++ b/sale_loyalty_auto_refresh/models/sale_order.py
@@ -27,7 +27,7 @@ class SaleOrder(models.Model):
         self_ctx = self.with_context(skip_auto_refresh_coupons=True)
         orders = super(SaleOrder, self_ctx).create(vals_list)
         orders._auto_refresh_coupons()
-        return orders
+        return self.browse(orders.ids)
 
     def write(self, vals):
         if self._check_skip_refresh():

--- a/sale_loyalty_auto_refresh/models/sale_order_line.py
+++ b/sale_loyalty_auto_refresh/models/sale_order_line.py
@@ -21,7 +21,7 @@ class SaleOrderLine(models.Model):
         self_ctx = self.with_context(skip_auto_refresh_coupons=True)
         lines = super(SaleOrderLine, self_ctx).create(vals_list)
         lines.order_id._auto_refresh_coupons()
-        return lines
+        return self.browse(lines.ids)
 
     def write(self, vals):
         if self._check_skip_refresh():


### PR DESCRIPTION
…to the inital context

Before this change, if so was modifed into the code just after its creation, the auto refresh of the coupon was never done since the new record was returned into a context disabling the auto refresh