### PR TITLE
[16.0][IMP] sale_loyalty_order_line_link: add a related so button

### DIFF
--- a/sale_loyalty_order_line_link/README.rst
+++ b/sale_loyalty_order_line_link/README.rst
@@ -40,6 +40,8 @@ It also links the reward lines to:
     - In a discount promo: the cheapest product, specific products or the whole order.
     - In a product promo: the product lines over which the reward is discounted.
 
+Additionally, this module adds a button in the loyalty program form view to open related sale orders.
+
 **Table of contents**
 
 .. contents::

--- a/sale_loyalty_order_line_link/__manifest__.py
+++ b/sale_loyalty_order_line_link/__manifest__.py
@@ -12,5 +12,9 @@
     "maintainers": ["chienandalu"],
     "license": "AGPL-3",
     "depends": ["sale_loyalty"],
-    "data": ["reports/sale_report_views.xml", "views/sale_order_views.xml"],
+    "data": [
+        "reports/sale_report_views.xml",
+        "views/sale_order_views.xml",
+        "views/loyalty_program_views.xml",
+    ],
 }

--- a/sale_loyalty_order_line_link/models/__init__.py
+++ b/sale_loyalty_order_line_link/models/__init__.py
@@ -1,1 +1,1 @@
-from . import sale_order
+from . import loyalty_program, sale_order

--- a/sale_loyalty_order_line_link/models/loyalty_program.py
+++ b/sale_loyalty_order_line_link/models/loyalty_program.py
@@ -1,0 +1,19 @@
+from odoo import fields, models
+
+
+class LoyaltyProgram(models.Model):
+    _inherit = "loyalty.program"
+
+    related_so_count = fields.Integer(compute="_compute_related_so_count")
+
+    def _compute_related_so_count(self):
+        for program in self:
+            program.related_so_count = self.env["sale.order"].search_count(
+                [("order_line.loyalty_program_id", "=", program.id)]
+            )
+
+    def action_open_related_sale_orders(self):
+        self.ensure_one()
+        action = self.env["ir.actions.actions"]._for_xml_id("sale.action_orders")
+        action["domain"] = [("order_line.loyalty_program_id", "=", self.id)]
+        return action

--- a/sale_loyalty_order_line_link/readme/DESCRIPTION.rst
+++ b/sale_loyalty_order_line_link/readme/DESCRIPTION.rst
@@ -9,3 +9,5 @@ It also links the reward lines to:
 
     - In a discount promo: the cheapest product, specific products or the whole order.
     - In a product promo: the product lines over which the reward is discounted.
+
+Additionally, this module adds a button in the loyalty program form view to open related sale orders.

--- a/sale_loyalty_order_line_link/static/description/index.html
+++ b/sale_loyalty_order_line_link/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -386,6 +386,7 @@ which discounts.</li>
 </ul>
 </dd>
 </dl>
+<p>Additionally, this module adds a button in the loyalty program form view to open related sale orders.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -439,7 +440,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/sale_loyalty_order_line_link/views/loyalty_program_views.xml
+++ b/sale_loyalty_order_line_link/views/loyalty_program_views.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="loyalty_program_view_form_inherit" model="ir.ui.view">
+        <field name="name">loyalty.program.form.inherit</field>
+        <field name="model">loyalty.program</field>
+        <field name="inherit_id" ref="loyalty.loyalty_program_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button
+                    name="action_open_related_sale_orders"
+                    type="object"
+                    class="oe_stat_button"
+                    icon="fa-list-ul"
+                >
+                    <div class="o_form_field o_stat_info">
+                        <span class="o_stat_value">
+                            <field name="related_so_count" />
+                        </span>
+                        <span class="o_stat_text">Related SO</span>
+                    </div>
+                </button>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
This PR adds a  smart button in the loyalty program form view to open related sale orders, enhancing traceability and management of related sales

![image](https://github.com/user-attachments/assets/4cab8c80-b8e4-4b54-b7dc-178dc81ec70c)
