### PR TITLE
[16.0][FIX-I18N] sale_loyalty_order_suggestion_multi_product: Correct translation of "and" in loyalty rule description

### DIFF
--- a/sale_loyalty_order_suggestion_multi_product/i18n/es.po
+++ b/sale_loyalty_order_suggestion_multi_product/i18n/es.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: \n"
+"POT-Creation-Date: 2025-05-05 05:58+0000\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Pedro M. Baeza <pedro.baeza@tecnativa.com>\n"
 "Language-Team: \n"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.6\n"
+"X-Generator: Poedit 3.4.2\n"
 
 #. module: sale_loyalty_order_suggestion_multi_product
 #. odoo-python
@@ -51,3 +51,10 @@ msgstr "Pedido de venta"
 #, python-format
 msgid "The quantities necessary to apply the promotion are not added."
 msgstr "No se han añadido las cantidades necesarias para aplicar la promoción."
+
+#. module: sale_loyalty_order_suggestion_multi_product
+#. odoo-python
+#: code:addons/sale_loyalty_order_suggestion_multi_product/wizard/sale_loyalty_reward_wizard.py:0
+#, python-format
+msgid "and"
+msgstr "y"

--- a/sale_loyalty_order_suggestion_multi_product/i18n/it.po
+++ b/sale_loyalty_order_suggestion_multi_product/i18n/it.po
@@ -6,15 +6,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2025-05-03 17:24+0000\n"
+"POT-Creation-Date: 2025-05-05 05:58+0000\n"
+"PO-Revision-Date: 2025-05-05 08:00+0200\n"
 "Last-Translator: mymage <stefano.consolaro@mymage.it>\n"
 "Language-Team: none\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.10.4\n"
+"X-Generator: Poedit 3.4.2\n"
 
 #. module: sale_loyalty_order_suggestion_multi_product
 #. odoo-python
@@ -52,3 +53,10 @@ msgid "The quantities necessary to apply the promotion are not added."
 msgstr ""
 "Non è stata aggiunta la quantità necessari per l'applicazione della "
 "promozione."
+
+#. module: sale_loyalty_order_suggestion_multi_product
+#. odoo-python
+#: code:addons/sale_loyalty_order_suggestion_multi_product/wizard/sale_loyalty_reward_wizard.py:0
+#, python-format
+msgid "and"
+msgstr "e"

--- a/sale_loyalty_order_suggestion_multi_product/i18n/sale_loyalty_order_suggestion_multi_product.pot
+++ b/sale_loyalty_order_suggestion_multi_product/i18n/sale_loyalty_order_suggestion_multi_product.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-05 05:58+0000\n"
+"PO-Revision-Date: 2025-05-05 05:58+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -46,4 +48,11 @@ msgstr ""
 #: code:addons/sale_loyalty_order_suggestion_multi_product/wizard/sale_loyalty_reward_wizard.py:0
 #, python-format
 msgid "The quantities necessary to apply the promotion are not added."
+msgstr ""
+
+#. module: sale_loyalty_order_suggestion_multi_product
+#. odoo-python
+#: code:addons/sale_loyalty_order_suggestion_multi_product/wizard/sale_loyalty_reward_wizard.py:0
+#, python-format
+msgid "and"
 msgstr ""

--- a/sale_loyalty_order_suggestion_multi_product/wizard/sale_loyalty_reward_wizard.py
+++ b/sale_loyalty_order_suggestion_multi_product/wizard/sale_loyalty_reward_wizard.py
@@ -53,14 +53,17 @@ class SaleLoyaltyRewardWizard(models.TransientModel):
 
     def _compute_loyalty_rule_line_description(self):
         self.loyalty_rule_line_description = False
-        products = list(
-            set(
-                self.selected_reward_id.program_id.rule_ids.loyalty_criteria_ids.product_ids
-            )
+        products = (
+            self.selected_reward_id.program_id.rule_ids.loyalty_criteria_ids.product_ids
         )
         if self.selected_reward_id and not self.applicable_program and products:
             if len(products) > 1:
-                products_str = f"{', '.join(map(str, [product.name for product in products][:-1]))} {_('and')} {[product.name for product in products][-1]}"  # noqa: B950
+                product_names = products.mapped("name")
+                products_str = "%s %s %s" % (
+                    ", ".join(product_names[:-1]),
+                    _("and"),
+                    product_names[-1],
+                )
             self.loyalty_rule_line_description = _(
                 "<b>* Required quantity:</b> 1 unit of %(products)s"
             ) % {"products": products_str}


### PR DESCRIPTION
cc @Tecnativa TT56160

@pedrobaeza please review