### PR TITLE
[14.0][FIX] sale_coupon_default_product: Avoid duplicates in group-by based on discount_line_product_id field

### DIFF
--- a/sale_coupon_free_shipping_default_product/__manifest__.py
+++ b/sale_coupon_free_shipping_default_product/__manifest__.py
@@ -1,6 +1,7 @@
 {
     "name": "Sale coupon free shipping default product",
-    "summary": "avoids creating multiple free shipping products",
+    "summary": """avoids creating multiple free shipping products and
+    creating multiple discount products if a coupon program is duplicated""",
     "version": "14.0.1.0.0",
     "category": "Hidden/Tools",
     "author": "Ooops, Odoo Community Association (OCA)",

--- a/sale_coupon_free_shipping_default_product/models/coupon_program.py
+++ b/sale_coupon_free_shipping_default_product/models/coupon_program.py
@@ -6,6 +6,9 @@ class CouponProgram(models.Model):
 
     @api.model
     def create(self, vals):
+        # avoids creating multiple products if a coupon program is duplicated
+        if self.discount_line_product_id:
+            vals["discount_line_product_id"] = self.discount_line_product_id.id
         if vals.get("reward_type") == "free_shipping":
             product = self.env.company.free_shipping_product_default
             if product:


### PR DESCRIPTION
Before this fix the product linked to the discount line product id field in a coupon program was duplicated generating different groups with the same product name in list view 