### PR TITLE
[16.0][FIX] sale_loyalty_order_suggestion: do not apply promotions automatically

### DIFF
--- a/sale_loyalty_order_suggestion/models/sale_order.py
+++ b/sale_loyalty_order_suggestion/models/sale_order.py
@@ -26,7 +26,6 @@ class SaleOrder(models.Model):
 
     def _get_available_programs(self):
         programs = self.env["loyalty.program"]
-        self._update_programs_and_rewards()
         programs_applied = self._get_reward_programs()
         domain = expression.AND(
             [

--- a/sale_loyalty_order_suggestion/tests/test_sale_loyalty_order_suggestion.py
+++ b/sale_loyalty_order_suggestion/tests/test_sale_loyalty_order_suggestion.py
@@ -1,5 +1,6 @@
 # Copyright 2023 Tecnativa - Pilar Vargas
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import Command
 from odoo.tests.common import Form, TransactionCase
 
 
@@ -148,3 +149,40 @@ class TestSaleLoyaltyOrderSuggestion(TransactionCase):
         self.assertEqual(len(wizard.loyalty_rule_line_ids), 0)
         wizard.action_apply()
         self.assertTrue(self.sale.order_line.filtered(lambda x: x.is_reward_line))
+
+    def test_no_extra_coupons_on_promotion_suggestion(self):
+        next_order_coupon = self.env["loyalty.program"].create(
+            {
+                "name": "Test Loyalty Next Order Coupons",
+                "program_type": "next_order_coupons",
+                "trigger": "auto",
+                "applies_on": "future",
+                "rule_ids": [
+                    Command.create(
+                        {
+                            "reward_point_mode": "order",
+                            "minimum_qty": 1,
+                            "minimum_amount": 50,
+                        },
+                    )
+                ],
+                "reward_ids": [
+                    Command.create(
+                        {
+                            "reward_type": "discount",
+                            "required_points": 1,
+                            "discount": 10,
+                            "discount_mode": "percent",
+                            "discount_applicability": "order",
+                        },
+                    )
+                ],
+            }
+        )
+        self.assertFalse(next_order_coupon.coupon_ids)
+        sale_form = Form(self.env["sale.order"])
+        sale_form.partner_id = self.partner
+        with sale_form.order_line.new() as line_form:
+            line_form.product_id = self.product_a
+            line_form.product_uom_qty = 1
+        self.assertFalse(next_order_coupon.coupon_ids)


### PR DESCRIPTION
When there is a promotion of the type next_order_coupons, this generates a coupon for an order that has not yet been saved and therefore that coupon does not have the associated order that generated it. Furthermore, this line is unnecessary since promotions are applied automatically and, if the order already meets the conditions for a promotion to be applied, it will still be suggested in the wizard and the products added/required to apply the selected promotion will also be reported.

For these reasons, the line is removed as it applies redundant and unnecessary logic that slows down the process and generates useless coupons.

This has been detected and applied in the migration to v18.

@tecnativa 

@carlos-lopez-tecnativa @pedrobaeza please review