### PR TITLE
[18.0][FIX] website_sale_loyalty_suggestion_wizard, sale_loyalty_order_suggestion: fix website promotion wizard issues

### DIFF
--- a/sale_loyalty_order_suggestion_multi_gift/wizard/sale_loyalty_reward_wizard.py
+++ b/sale_loyalty_order_suggestion_multi_gift/wizard/sale_loyalty_reward_wizard.py
@@ -6,7 +6,10 @@ class SaleLoyaltyRewardWizard(models.TransientModel):
 
     def action_apply(self):
         self._apply_loyalty_rule_lines_to_order()
-        super().action_apply()
+        super(
+            SaleLoyaltyRewardWizard,
+            self.with_context(skip_apply_loyalty_rule_lines=True),
+        ).action_apply()
         # It's necessary to adjust the order line when suggestions are made on order
         # lines that contain products that are part of a multi-gift reward, i.e. if
         # product A is added to the order and a promotion is suggested that has product

--- a/website_sale_loyalty_suggestion_wizard/static/src/js/website_sale_loyalty_suggestion_wizard_mixin.esm.js
+++ b/website_sale_loyalty_suggestion_wizard/static/src/js/website_sale_loyalty_suggestion_wizard_mixin.esm.js
@@ -17,15 +17,15 @@ var CouponSelectionMixin = {
      * @param {InputEvent} ev
      */
     _onchange_quantity: function (ev) {
-        var $row = $(ev.currentTarget).closest(".row.pl-3.pr-3");
+        var $row = $(ev.currentTarget).closest(".row.ps-3.pe-3");
         var $needed_qty_span = $row.find(".csw_criteria_needed_qty");
         var $criteria_icon = $row.find(".csw_criteria_icon");
         var $row_add_buttons = $row.find(".csw_add_quantity");
         var $inputs = $row.find("input");
         var needed_qty = parseInt($needed_qty_span.data("qty"), 10);
         var current_row_qty = 0;
-        $inputs.forEach((inp) => {
-            current_row_qty += parseInt(inp.value, 10);
+        $inputs.each(function () {
+            current_row_qty += parseInt(this.value, 10) || 0;
         });
         needed_qty = Math.max(needed_qty - current_row_qty, 0);
         if (needed_qty) {

--- a/website_sale_loyalty_suggestion_wizard/templates/wizard_templates.xml
+++ b/website_sale_loyalty_suggestion_wizard/templates/wizard_templates.xml
@@ -222,7 +222,7 @@
                     </div>
                 </t>
             </div>
-            <div class="row pl-3 pr-3">
+            <div class="row ps-3 pe-3">
                 <t
                     t-if="promotion_id.reward_ids not in list(order_id._get_claimable_rewards().values())"
                 >


### PR DESCRIPTION
This PR fixes two issues affecting the website loyalty promotion wizard.

In module website_sale_loyalty_suggestion_wizard the quantity onchange handler was iterating a jQuery collection using forEach, which is not supported and raises a Javascript error. The iteration has been replaced with each, which is the correct way to iterate jQuery collections.

In module sale_loyalty_order_suggestion the overridden action_apply method was calling _apply_loyalty_rule_lines_to_order before delegating to the parent implementation. Since the parent method already performs this operation, the rule lines were applied twice when using the website promotion wizard. The fix calls the parent method with skip_apply_loyalty_rule_lines=True to prevent the duplicate execution.

@Tecnativa TT61563

@victoralmau @pedrobaeza please review