### PR TITLE
[18.0][FIX] sale_loyalty_order_suggestion_multi_gift preserve same-product paid qty

### DIFF
--- a/sale_loyalty_order_suggestion_multi_gift/tests/test_sale_loyalty_order_suggestion_multi_gift.py
+++ b/sale_loyalty_order_suggestion_multi_gift/tests/test_sale_loyalty_order_suggestion_multi_gift.py
@@ -245,11 +245,11 @@ class TestSaleLoyaltyOrderSuggestion(BaseCommon):
             2,
         )
 
-    def test_04_same_product_buy2_get2_buy8_results_in_6_paid_and_2_free(self):
+    def test_04_same_product_buy2_get2_buy8_results_in_8_paid_and_2_free(self):
         # Check that if the order complies with the rules, even if the promotion is
         # suggested, the correct quantities are applied to the order lines.
         # For example: if the rule requires 2 and rewards 2 of the same product,
-        # when buying 8, 6 are paid for + 2 are rewarded.
+        # when buying 8, 8 are paid for + 2 are rewarded.
         sale_form = Form(self.env["sale.order"])
         sale_form.partner_id = self.partner
         with sale_form.order_line.new() as line_form:
@@ -275,7 +275,7 @@ class TestSaleLoyaltyOrderSuggestion(BaseCommon):
             sale.order_line.filtered(
                 lambda x: x.product_id == self.product_2 and not x.is_reward_line
             ).product_uom_qty,
-            6,
+            8,
         )
         self.assertEqual(
             sale.order_line.filtered(

--- a/sale_loyalty_order_suggestion_multi_gift/wizard/sale_loyalty_reward_wizard.py
+++ b/sale_loyalty_order_suggestion_multi_gift/wizard/sale_loyalty_reward_wizard.py
@@ -16,6 +16,9 @@ class SaleLoyaltyRewardWizard(models.TransientModel):
         # A as a reward, that order line will become an order reward line or the
         # quantity indicated in the promotion reward.
         if self.multi_gift_reward:
+            required_products = (
+                self.selected_reward_id.program_id.rule_ids._get_valid_products()
+            )
             for gift_line in self.loyalty_gift_line_ids:
                 selected_product = gift_line.selected_gift_id
                 product_qty = gift_line.line_id.reward_product_quantity
@@ -31,12 +34,16 @@ class SaleLoyaltyRewardWizard(models.TransientModel):
                     ).units_to_include
                     or False
                 )
-                if not units_to_include and order_line.product_uom_qty > product_qty:
-                    update_qty = order_line.product_uom_qty - product_qty
-                    if update_qty > 1:
-                        self._update_order_line_with_units(
-                            order_line, -abs(product_qty)
-                        )
+                qty_to_remove = min(order_line.product_uom_qty, product_qty)
+                if (
+                    selected_product not in required_products
+                    and not units_to_include
+                    and qty_to_remove
+                ):
+                    if order_line.product_uom_qty == qty_to_remove:
+                        order_line.unlink()
+                    else:
+                        self._update_order_line_with_units(order_line, -qty_to_remove)
         return {
             "type": "ir.actions.client",
             "tag": "soft_reload",


### PR DESCRIPTION
Do not reduce existing order lines when the required product is the same as the selected reward product. In that case, the reward must be added as a separate free line on top of the purchased quantity.

For different reward products already present in the order, convert the existing paid quantity into reward quantity by either reducing the line or removing it completely when the remaining quantity would be zero.

@Tecnativa TT62612

@CarlosRoca13 @victoralmau please review