### PR TITLE
[18.0][FIX] sale_loyalty_order_suggestion: Can't add a line on new order

### DIFF
--- a/sale_loyalty_order_suggestion/views/sale_order_views.xml
+++ b/sale_loyalty_order_suggestion/views/sale_order_views.xml
@@ -20,7 +20,6 @@
             <xpath expr="//field[@name='order_line']/kanban/control" position="before">
                 <field name="suggested_reward_ids" />
                 <field name="suggested_promotions" />
-                <field name="order_id" />
                 <field name="is_reward_line" />
             </xpath>
             <xpath


### PR DESCRIPTION
When creating a new order from the mobile view and trying to add a line before saving the order, an error is thrown because order_id is being set as undefined.

cc @Tecnativa TT62673

ping @pilarvargas-tecnativa @carlosdauden 