### PR TITLE
[18.0][FIX] loyalty_incompatibility: don't spread incompatibilities between programs

### DIFF
--- a/loyalty_incompatibility/models/loyalty_program.py
+++ b/loyalty_incompatibility/models/loyalty_program.py
@@ -1,7 +1,7 @@
 # Copyright 2021 Tecnativa - David Vidal
 # Copyright 2023 Tecnativa - Stefan Ungureanu
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import fields, models
+from odoo import Command, fields, models
 
 
 class LoyaltyProgram(models.Model):
@@ -20,7 +20,18 @@ class LoyaltyProgram(models.Model):
     def _inverse_incompatible_promotion_ids(self):
         """We'll be ensuring that any program that could have been removed from the
         field will be compatible again and that any new program in the field will
-        be incompatible with this one. So we will ensure that A ⊥ B as B ⊥ A"""
+        be incompatible with this one. So we will ensure that A ⊥ B as B ⊥ A
+
+        Every counterpart is updated one by one with a link/unlink command. Reading
+        or assigning the field over a multi-record set would operate on the union of
+        all their incompatibilities and write that union back to each of them, which
+        spreads unrelated programs across the whole group.
+
+        The sync only has to run for the program that was written, so the recursive
+        call triggered on each counterpart is skipped through the context.
+        """
+        if self.env.context.get("skip_incompatible_promotion_sync"):
+            return
         for program in self:
             incompatible_programs = self.search(
                 [
@@ -28,8 +39,15 @@ class LoyaltyProgram(models.Model):
                     ("id", "!=", program.id),
                 ]
             )
+            to_add_programs = program.incompatible_promotion_ids - incompatible_programs
             to_remove_programs = (
                 incompatible_programs - program.incompatible_promotion_ids
             )
-            program.incompatible_promotion_ids.incompatible_promotion_ids |= program
-            to_remove_programs.incompatible_promotion_ids -= program
+            for counterpart in to_add_programs:
+                counterpart.with_context(
+                    skip_incompatible_promotion_sync=True
+                ).incompatible_promotion_ids = [Command.link(program.id)]
+            for counterpart in to_remove_programs:
+                counterpart.with_context(
+                    skip_incompatible_promotion_sync=True
+                ).incompatible_promotion_ids = [Command.unlink(program.id)]

--- a/loyalty_incompatibility/readme/CONTRIBUTORS.md
+++ b/loyalty_incompatibility/readme/CONTRIBUTORS.md
@@ -5,3 +5,5 @@
   - Pilar Vargas
 - [Heliconia Solutions Pvt. Ltd.](https://www.heliconia.io)
   - Bhavesh Heliconia
+- [Escodoo](https://www.escodoo.com.br):
+  - Kaynnan Lemes \<<kaynnan.lemes@escodoo.com.br>\>

--- a/loyalty_incompatibility/tests/test_loyalty_incompatibility.py
+++ b/loyalty_incompatibility/tests/test_loyalty_incompatibility.py
@@ -153,3 +153,42 @@ class LoyaltyIncompatibilityCase(BaseCommon):
             self.promotion_2.incompatible_promotion_ids,
             "New incompatibility should be bidirectional",
         )
+
+    def test_incompatibility_not_propagated_between_programs(self):
+        """Sharing a counterpart must not make two programs incompatible.
+
+        With A ⊥ {B, C}, setting D ⊥ {B} must leave D incompatible with B
+        only: C is unrelated to D and must stay out of it.
+        """
+        program_b = self.promotion
+        program_c = self.promotion_2
+        program_a = self.coupon_program_with_incompatibility
+        program_d = self.coupon_program_without_incompatibility
+
+        program_a.incompatible_promotion_ids = [
+            Command.set((program_b | program_c).ids)
+        ]
+        program_d.incompatible_promotion_ids = [Command.set(program_b.ids)]
+
+        self.assertEqual(
+            program_d.incompatible_promotion_ids,
+            program_b,
+            "Only the selected program must be incompatible with D.",
+        )
+        self.assertNotIn(
+            program_d,
+            program_c.incompatible_promotion_ids,
+            "C was never selected on D and must not gain it back.",
+        )
+
+    def test_incompatibility_removal_is_symmetric(self):
+        """Removing a counterpart clears the relation on both sides."""
+        program_a = self.coupon_program_with_incompatibility
+        program_b = self.promotion
+
+        self.assertIn(program_b, program_a.incompatible_promotion_ids)
+
+        program_a.incompatible_promotion_ids = [Command.clear()]
+
+        self.assertFalse(program_a.incompatible_promotion_ids)
+        self.assertNotIn(program_a, program_b.incompatible_promotion_ids)


### PR DESCRIPTION
Fixes #336.

Selecting one incompatible program silently pulls in the others it was already incompatible with. With A ⊥ {B, C}, setting D ⊥ {B} leaves D incompatible with both B and C.

The inverse keeps the relation symmetric with:

```python
program.incompatible_promotion_ids.incompatible_promotion_ids |= program
```

`program.incompatible_promotion_ids` is usually more than one record, and reading an x2m over a multi-record set returns the union of their values, which then gets written back to every one of them. So B and C, which only had A in common, end up carrying each other's incompatibilities.

Each counterpart is now updated on its own with a link/unlink command, so nothing leaks between them. The recursive call the write triggers on the counterpart is skipped through the context, as the sync only needs to run for the program that was actually written.

Added a test reproducing the report, plus one covering symmetric removal, which had no coverage.